### PR TITLE
Add llvmdev in conda-recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,6 @@ requirements:
         - python
         - setuptools
         - cython
-        - llvm-spirv
         - numba
         - dpctl
         - dpnp
@@ -27,6 +26,7 @@ requirements:
         - dpctl
         - spirv-tools
         - llvm-spirv
+        - llvmdev
         - dpnp
 
 about:


### PR DESCRIPTION
`llvmdev` is necessary in `numba-dppy`.
Previously IntelPython/Numba required it.

Also `llvm-spirv` is not used in build.