### PR TITLE
Move numba/dppl_config.py to numba_dppy/config.py

### DIFF
--- a/numba_dppy/__init__.py
+++ b/numba_dppy/__init__.py
@@ -506,14 +506,14 @@ from __future__ import print_function, absolute_import, division
 from numba import config
 import numba.testing
 
-from numba.dppl_config import *
-if dppl_present:
+from .config import dppy_present
+if dppy_present:
     from .device_init import *
 else:
     raise ImportError("Importing dppl failed")
 
 def test(*args, **kwargs):
-    if not dppl_present and not is_available():
+    if not dppy_present and not is_available():
         dppl_error()
 
     return numba.testing.test("numba_dppy.tests", *args, **kwargs)

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -1,0 +1,6 @@
+try:
+    import dpctl
+
+    dppy_present = dpctl.has_sycl_platforms() and dpctl.has_gpu_queues()
+except:
+    dppy_present = False

--- a/numba_dppy/dppl_offload_dispatcher.py
+++ b/numba_dppy/dppl_offload_dispatcher.py
@@ -1,13 +1,13 @@
 from numba.core import dispatcher, compiler
 from numba.core.registry import cpu_target, dispatcher_registry
-import numba.dppl_config as dppl_config
+import numba_dppy.config as dppy_config
 
 
 class DpplOffloadDispatcher(dispatcher.Dispatcher):
     targetdescr = cpu_target
 
     def __init__(self, py_func, locals={}, targetoptions={}, impl_kind='direct', pipeline_class=compiler.Compiler):
-        if dppl_config.dppl_present:
+        if dppy_config.dppy_present:
             from numba_dppy.compiler import DPPLCompiler
             targetoptions['parallel'] = True
             dispatcher.Dispatcher.__init__(self, py_func, locals=locals,

--- a/numba_dppy/tests/__init__.py
+++ b/numba_dppy/tests/__init__.py
@@ -3,14 +3,14 @@ from numba.testing import load_testsuite
 from os.path import dirname, join
 
 
-import numba.dppl_config as dppl_config
+import numba_dppy.config as dppy_config
 
 def load_tests(loader, tests, pattern):
 
     suite = SerialSuite()
     this_dir = dirname(__file__)
 
-    if dppl_config.dppl_present:
+    if dppy_config.dppy_present:
         suite.addTests(load_testsuite(loader, join(this_dir, 'dppl')))
     else:
         print("skipped DPPL tests")


### PR DESCRIPTION
dppl_config.py contains flag `dppl_present` which indicate that `dpCtl`
and devices are available.
As `numba-dppy` will depend on `dpCtl` then the check is not necessary.
Also checking for available platform and device could be done in
`numba-dppy`. It also can raise and exception on import as before.

`dppl_present` also renamed to `dppy_present`.

Related to https://github.com/IntelPython/numba/pull/106