### PR TITLE
Build with dpNP only on Linux

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
         - cython
         - numba
         - dpctl
-        - dpnp
+        - dpnp  # [linux]
     run:
         - python
         - numba >=0.51
@@ -27,7 +27,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp
+        - dpnp  # [linux]
 
 about:
     home: https://github.com/IntelPython/numba-dppy


### PR DESCRIPTION
`dpNP` is not available for Windows yet.

Also, `numba-dppy` does not support osx.