### PR TITLE
Ignore specific dpnp package version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp 0.4.*  # [linux]
+        - dpnp 0.4.*,!=0.4.0=*_155  # [linux]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
         - cython
         - numba
         - dpctl >=0.5.1rc1
-        - dpnp 0.4.*  # [linux]
+        - dpnp 0.4.*|0.4.0=*_59  # [linux]
     run:
         - python
         - numba >=0.51
@@ -27,7 +27,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp <0.5.0a0,!=0.4.0=*_155  # [linux]
+        - dpnp 0.4.*|0.4.0=*_59  # [linux]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp 0.4.*,!=0.4.0=*_155  # [linux]
+        - dpnp <0.5.0a0,!=0.4.0=*_155  # [linux]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
         - cython
         - numba
         - dpctl >=0.5.1rc1
-        - dpnp 0.4.*|0.4.0=*_59  # [linux]
+        - dpnp 0.4.0=*_59  # [linux]
     run:
         - python
         - numba >=0.51
@@ -27,7 +27,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp 0.4.*|0.4.0=*_59  # [linux]
+        - dpnp 0.4.0=*_59  # [linux]
 
 test:
   requires:


### PR DESCRIPTION
I did not find a way to use dpnp 0.4.0 but not 0.4.0=*_155. So I have to hardcode the last working package build number.
It is temporary solution to fix current CI.