### PR TITLE
Don't create a new copy of a usm shared array data pointers for kernel call.

### DIFF
--- a/numba_dppy/examples/pa_examples/test1-2d.py
+++ b/numba_dppy/examples/pa_examples/test1-2d.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from numba import njit, gdb
 import numpy as np
 import dpctl

--- a/numba_dppy/examples/pa_examples/test1-3d.py
+++ b/numba_dppy/examples/pa_examples/test1-3d.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from numba import njit, gdb
 import numpy as np
 import dpctl

--- a/numba_dppy/examples/pa_examples/test1-4d.py
+++ b/numba_dppy/examples/pa_examples/test1-4d.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from numba import njit, gdb
 import numpy as np
 import dpctl

--- a/numba_dppy/examples/pa_examples/test1-5d.py
+++ b/numba_dppy/examples/pa_examples/test1-5d.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from numba import njit, gdb
 import numpy as np
 import dpctl

--- a/numba_dppy/examples/pa_examples/test1.py
+++ b/numba_dppy/examples/pa_examples/test1.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from numba import njit
 import numpy as np
 import dpctl

--- a/numba_dppy/numpy_usm_shared.py
+++ b/numba_dppy/numpy_usm_shared.py
@@ -19,6 +19,7 @@ import numba
 from types import FunctionType as ftype, BuiltinFunctionType as bftype
 from numba import types
 from numba.extending import typeof_impl, register_model, type_callable, lower_builtin
+from numba.core.datamodel.registry import register_default as register_model_default
 from numba.np import numpy_support
 from numba.core.pythonapi import box, allocator
 from llvmlite import ir
@@ -45,6 +46,7 @@ from numba.np.arrayobj import _array_copy
 
 import dpctl.dptensor.numpy_usm_shared as nus
 from dpctl.dptensor.numpy_usm_shared import ndarray, functions_list, class_list
+from . import target as dppy_target
 
 
 debug = config.DEBUG
@@ -140,6 +142,9 @@ def typeof_ta_ndarray(val, c):
 # This tells Numba to use the default Numpy ndarray data layout for
 # object of type UsmArray.
 register_model(UsmSharedArrayType)(numba.core.datamodel.models.ArrayModel)
+dppy_target.spirv_data_model_manager.register(
+    UsmSharedArrayType, numba.core.datamodel.models.ArrayModel
+)
 
 # This tells Numba how to convert from its native representation
 # of a UsmArray in a njit function back to a Python UsmArray.

--- a/numba_dppy/ocl/atomics/__init__.py
+++ b/numba_dppy/ocl/atomics/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import os.path
 

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -46,29 +46,30 @@ def test_no_copy_usm_shared(capfd):
     targetctx = cpu_target.target_context
     args = typingctx.resolve_argument_type(a)
 
-    cres = compiler.compile_extra(
-        typingctx=typingctx,
-        targetctx=targetctx,
-        func=fn,
-        args=tuple([args]),
-        return_type=args,
-        flags=flags,
-        locals={},
-        pipeline_class=DPPYCompiler,
-    )
+    with dpctl.device_context("opencl:gpu:0"):
+        cres = compiler.compile_extra(
+            typingctx=typingctx,
+            targetctx=targetctx,
+            func=fn,
+            args=tuple([args]),
+            return_type=args,
+            flags=flags,
+            locals={},
+            pipeline_class=DPPYCompiler,
+        )
 
-    assert "DPCTLQueue_Memcpy" not in cres.library.get_llvm_str()
+        assert "DPCTLQueue_Memcpy" not in cres.library.get_llvm_str()
 
-    args = typingctx.resolve_argument_type(b)
-    cres = compiler.compile_extra(
-        typingctx=typingctx,
-        targetctx=targetctx,
-        func=fn,
-        args=tuple([args]),
-        return_type=args,
-        flags=flags,
-        locals={},
-        pipeline_class=DPPYCompiler,
-    )
+        args = typingctx.resolve_argument_type(b)
+        cres = compiler.compile_extra(
+            typingctx=typingctx,
+            targetctx=targetctx,
+            func=fn,
+            args=tuple([args]),
+            return_type=args,
+            flags=flags,
+            locals={},
+            pipeline_class=DPPYCompiler,
+        )
 
-    assert "DPCTLQueue_Memcpy" in cres.library.get_llvm_str()
+        assert "DPCTLQueue_Memcpy" in cres.library.get_llvm_str()

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 import numpy as np
 from numba import njit, prange
@@ -10,10 +24,12 @@ import numba_dppy.numpy_usm_shared as nus
 from numba_dppy.compiler import DPPYCompiler
 from numba.core.registry import cpu_target
 
+
 def fn(a):
     for i in prange(a.size):
         a[i] += 1
     return a
+
 
 def test_no_copy_usm_shared(capfd):
     a = usmarray.ones(10, dtype=np.int64)
@@ -23,7 +39,7 @@ def test_no_copy_usm_shared(capfd):
     flags = compiler.Flags()
     flags.set("no_compile")
     flags.set("no_cpython_wrapper")
-    flags.set('auto_parallel', cpu.ParallelOptions(True))
+    flags.set("auto_parallel", cpu.ParallelOptions(True))
     flags.unset("nrt")
 
     typingctx = cpu_target.typing_context
@@ -31,29 +47,28 @@ def test_no_copy_usm_shared(capfd):
     args = typingctx.resolve_argument_type(a)
 
     cres = compiler.compile_extra(
-		typingctx=typingctx,
-		targetctx=targetctx,
-		func=fn,
-		args=tuple([args]),
-		return_type=args,
-		flags=flags,
-		locals={},
-		pipeline_class=DPPYCompiler,)
-
+        typingctx=typingctx,
+        targetctx=targetctx,
+        func=fn,
+        args=tuple([args]),
+        return_type=args,
+        flags=flags,
+        locals={},
+        pipeline_class=DPPYCompiler,
+    )
 
     assert "DPCTLQueue_Memcpy" not in cres.library.get_llvm_str()
 
-
     args = typingctx.resolve_argument_type(b)
     cres = compiler.compile_extra(
-		typingctx=typingctx,
-		targetctx=targetctx,
-		func=fn,
-		args=tuple([args]),
-		return_type=args,
-		flags=flags,
-		locals={},
-		pipeline_class=DPPYCompiler,)
-
+        typingctx=typingctx,
+        targetctx=targetctx,
+        func=fn,
+        args=tuple([args]),
+        return_type=args,
+        flags=flags,
+        locals={},
+        pipeline_class=DPPYCompiler,
+    )
 
     assert "DPCTLQueue_Memcpy" in cres.library.get_llvm_str()

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -1,0 +1,59 @@
+import pytest
+import numpy as np
+from numba import njit, prange
+
+from numba.core import compiler, cpu
+
+import dpctl.dptensor.numpy_usm_shared as usmarray
+import numba_dppy.numpy_usm_shared as nus
+
+from numba_dppy.compiler import DPPYCompiler
+from numba.core.registry import cpu_target
+
+def fn(a):
+    for i in prange(a.size):
+        a[i] += 1
+    return a
+
+def test_no_copy_usm_shared(capfd):
+    a = usmarray.ones(10, dtype=np.int64)
+    b = np.ones(10, dtype=np.int64)
+    f = njit(fn)
+
+    flags = compiler.Flags()
+    flags.set("no_compile")
+    flags.set("no_cpython_wrapper")
+    flags.set('auto_parallel', cpu.ParallelOptions(True))
+    flags.unset("nrt")
+
+    typingctx = cpu_target.typing_context
+    targetctx = cpu_target.target_context
+    args = typingctx.resolve_argument_type(a)
+
+    cres = compiler.compile_extra(
+		typingctx=typingctx,
+		targetctx=targetctx,
+		func=fn,
+		args=tuple([args]),
+		return_type=args,
+		flags=flags,
+		locals={},
+		pipeline_class=DPPYCompiler,)
+
+
+    assert "DPCTLQueue_Memcpy" not in cres.library.get_llvm_str()
+
+
+    args = typingctx.resolve_argument_type(b)
+    cres = compiler.compile_extra(
+		typingctx=typingctx,
+		targetctx=targetctx,
+		func=fn,
+		args=tuple([args]),
+		return_type=args,
+		flags=flags,
+		locals={},
+		pipeline_class=DPPYCompiler,)
+
+
+    assert "DPCTLQueue_Memcpy" in cres.library.get_llvm_str()

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -20,6 +20,7 @@ from numba.core import compiler, cpu
 
 import dpctl.dptensor.numpy_usm_shared as usmarray
 import numba_dppy.numpy_usm_shared as nus
+import dpctl
 
 from numba_dppy.compiler import DPPYCompiler
 from numba.core.registry import cpu_target


### PR DESCRIPTION
In the code that forms the kernel args, we now look to see if the array type is actually a USM shared type.  If so, we just place the data pointer directly into the kernel arg and so we avoid all the overhead of creating a new USM buffer and copying data there before the kernel and back afterwards.