### PR TITLE
Make Test Matrix table smaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ Read this guide for additional features [INDEX.md](docs/INDEX.md)
 
 ## Test Matrix:
 
-| # |    OS   | Distribution | Python |   Architecture  | Test type | IntelOneAPI |                                   Build Commands                                  |    Dependencies    | Backend     |
-|:-:|:-------:|:------------:|:------:|:---------------:|:---------:|:-----------:|:---------------------------------------------------------------------------------:|:------------------:|:-----------:|
-| 1 |  Linux  | Ubuntu 20.04 |   3.7  | Gen9 Integrated |     CI    |    2021.2   | python setup.py install; pytest -q -ra --disable-warnings --pyargs numba_dppy -vv | Numba, NumPy, dpnp | OCL, L0-1.0 |
-| 2 |  Linux  | Ubuntu 20.04 |   3.7  |  Gen12 Discrete |   Manual  |    2021.2   | python setup.py install; pytest -q -ra --disable-warnings --pyargs numba_dppy -vv | Numba, NumPy, dpnp | OCL, L0-1.0 |
-| 3 | Linux   | Ubuntu 20.04 |   3.7  |    i7-10710U    |     CI    |    2021.2   | python setup.py install; pytest -q -ra --disable-warnings --pyargs numba_dppy -vv | Numba, NumPy, dpnp | OCL, L0-1.0 |
-| 4 | Windows |      10      |   3.7  | Gen9 Integrated |     CI    |    2021.2   | python setup.py install; pytest -q -ra --disable-warnings --pyargs numba_dppy -vv |    Numba, NumPy    |     OCL     |
-| 5 | Windows |      10      |   3.7  |     i7-10710    |     CI    |    2021.2   | python setup.py install; python -q -ra --disable-warnings --pyargs numba_dppy -vv |    Numba, NumPy    |     OCL     |
+|   #   |   OS    | Distribution | Python |  Architecture   | Test type | IntelOneAPI | Build Commands |    Dependencies    |   Backend   |
+| :---: | :-----: | :----------: | :----: | :-------------: | :-------: | :---------: | :------------: | :----------------: | :---------: |
+|   1   |  Linux  | Ubuntu 20.04 |  3.7   | Gen9 Integrated |    CI     |   2021.2    |      (1)       | Numba, NumPy, dpnp | OCL, L0-1.0 |
+|   2   |  Linux  | Ubuntu 20.04 |  3.7   | Gen12 Discrete  |  Manual   |   2021.2    |      (1)       | Numba, NumPy, dpnp | OCL, L0-1.0 |
+|   3   |  Linux  | Ubuntu 20.04 |  3.7   |    i7-10710U    |    CI     |   2021.2    |      (1)       | Numba, NumPy, dpnp | OCL, L0-1.0 |
+|   4   | Windows |      10      |  3.7   | Gen9 Integrated |    CI     |   2021.2    |      (1)       |    Numba, NumPy    |     OCL     |
+|   5   | Windows |      10      |  3.7   |    i7-10710     |    CI     |   2021.2    |      (1)       |    Numba, NumPy    |     OCL     |
+
+(1): `python setup.py install; pytest -q -ra --disable-warnings --pyargs numba_dppy -vv`


### PR DESCRIPTION
Fixes #307.
I have moved long line in columns "Build Commands" to a line under the table.
Also I have found that the last line was incorrect.