### PR TITLE
Use correct names for other products dpctl, Numba, dpnp

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://intelpython.github.io/dpnp/
 
 ## dppy
 
-dppy is a proof-of-concept backend for NUMBA to support compilation for
+dppy is a proof-of-concept backend for Numba to support compilation for
 Intel CPU and GPU architectures.
 The present implementation of dpPy is based on OpenCL 2.1, but is likely
 to change in the future to rely on Sycl/DPC++ or Intel Level-0 driver API.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # numba-dppy
 
-## Numba + dpPy + dpCtl + dpNP = numba-dppy
+## Numba + dppy + dpctl + dpnp = numba-dppy
 
 `numba-dppy` extends Numba with a new backend to support compilation
 for Intel CPU and GPU architectures.
@@ -22,16 +22,16 @@ https://intelpython.github.io/dpnp/
 ## Dependencies
 
 * numba 0.52.* (IntelPython/numba)
-* dpCtl 0.6.*
-* dpNP >=0.5.1 (optional)
+* dpctl 0.6.*
+* dpnp >=0.5.1 (optional)
 * llvm-spirv (SPIRV generation from LLVM IR)
 * llvmdev (LLVM IR generation)
 * spirv-tools
 * scipy (for testing)
 
-## dpPy
+## dppy
 
-dpPy is a proof-of-concept backend for NUMBA to support compilation for
+dppy is a proof-of-concept backend for NUMBA to support compilation for
 Intel CPU and GPU architectures.
 The present implementation of dpPy is based on OpenCL 2.1, but is likely
 to change in the future to rely on Sycl/DPC++ or Intel Level-0 driver API.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Welcome to numba-dppy's documentation!
 ``numba-dppy`` is a standalone extension to the `Numba
 <https://numba.pydata.org/>`_ JIT compiler that adds `SYCL
 <https://www.khronos.org/sycl/>`_ programming capabilities to Numba.
-``numba-dppy`` uses `dpCtl <https://github.com/IntelPython/dpctl>`_ to support
+``numba-dppy`` uses `dpctl <https://github.com/IntelPython/dpctl>`_ to support
 SYCL features and currently Intel's `DPC++ <https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md>`_ is the only SYCL runtime supported by
 ``numba-dppy``.
 

--- a/docs/user_guides/getting_started.rst
+++ b/docs/user_guides/getting_started.rst
@@ -7,7 +7,7 @@ Installation
 ``numba-dppy`` depends on following components:
 
 * numba 0.52.* (`Intel Python Numba`_)
-* dpctl 0.6.* (`Intel Python dpCtl`_)
+* dpctl 0.6.* (`Intel Python dpctl`_)
 * dpnp >=0.5.1 (optional, `Intel Python DPNP`_)
 * `llvm-spirv`_ (SPIRV generation from LLVM IR)
 * `llvmdev`_ (LLVM IR generation)
@@ -111,8 +111,8 @@ code-generation for a SYCL device. Work in underway to upstream all patches, so
 that in future ``numba-dppy`` can work with upstream Numba.
 
 .. _`Intel Python Numba`: https://github.com/IntelPython/numba
-.. _`Intel Python dpCtl`: https://github.com/IntelPython/dpctl
-.. _`Intel Python DPNP`: https://github.com/IntelPython/dpnp
+.. _`Intel Python dpctl`: https://github.com/IntelPython/dpctl
+.. _`Intel Python dpnp`: https://github.com/IntelPython/dpnp
 .. _`llvm-spirv`: https://anaconda.org/intel/llvm-spirv
 .. _`llvmdev`: https://anaconda.org/intel/llvmdev
 .. _`spirv-tools`: https://anaconda.org/intel/spirv-tools

--- a/docs/user_guides/kernel_programming_guide/random.rst
+++ b/docs/user_guides/kernel_programming_guide/random.rst
@@ -5,9 +5,9 @@ Random Number Generation
 executed on the SYCL-supported Device.
 
 ``numba-dppy`` provides access to NumPy random algorithms that can be executed on the
-SYCL-supported device via integration with `dpNP Random`_.
+SYCL-supported device via integration with `dpnp Random`_.
 
-.. _`dpNP Random`: https://intelpython.github.io/dpnp/reference/comparison.html#random-sampling
+.. _`dpnp Random`: https://intelpython.github.io/dpnp/reference/comparison.html#random-sampling
 
 
 DPPY supported functions


### PR DESCRIPTION
using lower case for `dppy`, `dpnp`, `dpctl`. The style of camel casing just did not work with the masses.