### PR TITLE
Add DeviceArray class

### DIFF
--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -34,7 +34,7 @@ from . import spirv_generator
 import os
 from numba.core.compiler import DefaultPassBuilder, CompilerBase
 from numba_dppy.dppy_parfor_diagnostics import ExtendedParforDiagnostics
-from numba_dppy.dppy_devicearray import DPPYDeviceArray
+from numba_dppy.dppy_devicearray import DeviceArray
 
 
 DEBUG = os.environ.get("NUMBA_DPPY_DEBUG", None)
@@ -478,7 +478,7 @@ class DPPYKernel(DPPYKernelBase):
         device_arrs.append(None)
 
         if isinstance(ty, types.Array):
-            if isinstance(val, DPPYDeviceArray):
+            if isinstance(val, DeviceArray):
                 assert sycl_queue.equals(val.get_queue()), (
                     "Current SYCL queue and queue used for allocating argument %d does not match!"
                     % idx

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -479,16 +479,20 @@ class DPPYKernel(DPPYKernelBase):
 
         if isinstance(ty, types.Array):
             if isinstance(val, DeviceArray):
-                assert sycl_queue.equals(val.get_queue()), (
-                    "Current SYCL queue and queue used for allocating argument %d does not match!"
+                assert sycl_queue.get_sycl_context().equals(
+                    val.get_queue().get_sycl_context()
+                ), (
+                    "Current SYCL context and context used for allocating argument %d does not match!"
                     % idx
                 )
                 device_arrs[-1] = (val.base, val, val)
                 self._unpack_device_array_argument(val, kernelargs)
             else:
                 if hasattr(val.base, "__sycl_usm_array_interface__"):
-                    assert sycl_queue.equals(val.base._queue), (
-                        "Current SYCL queue and queue used for allocating argument %d does not match!"
+                    assert sycl_queue.get_sycl_context().equals(
+                        val.base._queue.get_sycl_context()
+                    ), (
+                        "Current SYCL context and context used for allocating argument %d does not match!"
                         % idx
                     )
                     self._unpack_device_array_argument(val, kernelargs)

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -406,9 +406,9 @@ class DPPYKernel(DPPYKernelBase):
         retr = []  # hold functors for writeback
         kernelargs = []
         internal_device_arrs = []
-        for idx, (ty, val, access_type) in enumerate(zip(
-            self.argument_types, args, self.ordered_arg_access_types
-        )):
+        for idx, (ty, val, access_type) in enumerate(
+            zip(self.argument_types, args, self.ordered_arg_access_types)
+        ):
             self._unpack_argument(
                 ty,
                 val,
@@ -417,7 +417,7 @@ class DPPYKernel(DPPYKernelBase):
                 kernelargs,
                 internal_device_arrs,
                 access_type,
-                idx
+                idx,
             )
 
         self.sycl_queue.submit(
@@ -481,7 +481,10 @@ class DPPYKernel(DPPYKernelBase):
             if isinstance(val, DPPYDeviceArray):
                 device_arrs[-1] = (val.base, val, val)
                 self._unpack_device_array_argument(val, kernelargs)
-                assert sycl_queue.equals(val.queue), ("Current SYCL queue and queue used for allocating argument %d does not match!" % (idx + 1))
+                assert sycl_queue.equals(val.queue), (
+                    "Current SYCL queue and queue used for allocating argument %d does not match!"
+                    % (idx + 1)
+                )
             else:
                 if hasattr(val.base, "__sycl_usm_array_interface__"):
                     self._unpack_device_array_argument(val, kernelargs)

--- a/numba_dppy/device_init.py
+++ b/numba_dppy/device_init.py
@@ -45,7 +45,7 @@ from . import initialize
 from .decorators import kernel, func, autojit
 import dpctl
 from . import target
-from .dppy_devicearray import DPPYDeviceArray, to_device
+from .dppy_devicearray import DeviceArray, to_device
 
 
 def is_available():

--- a/numba_dppy/device_init.py
+++ b/numba_dppy/device_init.py
@@ -45,6 +45,7 @@ from . import initialize
 from .decorators import kernel, func, autojit
 import dpctl
 from . import target
+from .dppy_devicearray import DPPYDeviceArray
 
 
 def is_available():

--- a/numba_dppy/device_init.py
+++ b/numba_dppy/device_init.py
@@ -45,7 +45,7 @@ from . import initialize
 from .decorators import kernel, func, autojit
 import dpctl
 from . import target
-from .dppy_devicearray import DPPYDeviceArray
+from .dppy_devicearray import DPPYDeviceArray, to_device
 
 
 def is_available():

--- a/numba_dppy/dppy_devicearray.py
+++ b/numba_dppy/dppy_devicearray.py
@@ -19,8 +19,8 @@ from numba.core import types
 from numba.np import numpy_support
 
 
-class DPPYDeviceArray(object):
-    """Device Array type for dppy"""
+class DeviceArray(object):
+    """An on-GPU array type"""
 
     def __init__(self, shape, strides, dtype, usm_memory=None, queue=None):
         """
@@ -131,8 +131,8 @@ class DPPYDeviceArray(object):
 
 
 def to_device(ary, queue=None):
-    """Convenience function to create a DPPYDeviceArray from a np.ndarray
-    and copy data from ary to the created DPPYDeviceArray.
+    """Convenience function to create a DeviceArray from a np.ndarray
+    and copy data from ary to the created DeviceArray.
 
     Args
     ----
@@ -142,7 +142,7 @@ def to_device(ary, queue=None):
     if ary is None or not isinstance(ary, np.ndarray):
         raise ValueError("ary has to be a valid np.ndarray")
 
-    da = DPPYDeviceArray(ary.shape, ary.strides, ary.dtype, queue=queue)
+    da = DeviceArray(ary.shape, ary.strides, ary.dtype, queue=queue)
     da.copy_to_device(ary)
 
     return da

--- a/numba_dppy/dppy_devicearray.py
+++ b/numba_dppy/dppy_devicearray.py
@@ -137,3 +137,19 @@ class DPPYDeviceArray(object):
 
         np.copyto(ary, self.hostary)
         return ary
+
+
+def to_device(ary):
+    """Convenience function to create a DPPYDeviceArray from a np.ndarray
+    Args
+    ----
+    ary
+        np.ndarray.
+    """
+    if ary is None or not isinstance(ary, np.ndarray):
+        raise ValueError("ary has to be a valid np.ndarray")
+
+    da = DPPYDeviceArray(ary.shape, ary.strides, ary.dtype)
+    da.copy_to_device(ary)
+
+    return da

--- a/numba_dppy/dppy_devicearray.py
+++ b/numba_dppy/dppy_devicearray.py
@@ -141,6 +141,8 @@ class DPPYDeviceArray(object):
 
 def to_device(ary):
     """Convenience function to create a DPPYDeviceArray from a np.ndarray
+    and copy data from ary to the created DPPYDeviceArray.
+
     Args
     ----
     ary

--- a/numba_dppy/dppy_devicearray.py
+++ b/numba_dppy/dppy_devicearray.py
@@ -1,0 +1,119 @@
+import numpy as np
+import dpctl.memory as dpctl_mem
+import dpctl
+from numba.core import types
+
+
+class DPPYDeviceArray(object):
+    """Device Array type for dppy
+    """
+    def __init__(self, shape, strides, dtype, usm_memory=None, queue=None):
+        """
+        Args
+        ----
+
+        shape
+            array shape.
+        strides
+            array strides.
+        dtype
+            data type as numpy.dtype.
+        usm_memory
+            user provided device memory for the ndarray data buffer
+        """
+
+        # dpctl.memory.MemoryUSMShared does not cache the queue. Without
+        # a reference to the Sycl queue in the usm_memory we need to
+        # store the reference in this class. Until dpctl.memory.MemoryUSMShared
+        # provides a reference to the queue we can not allow any usm_memory
+        # being passed to this class.
+        if usm_memory is not None:
+            raise ValueError('Pre-allocated usm_memory is not supported')
+
+        if isinstance(shape, int):
+            shape = (shape,)
+        if isinstance(strides, int):
+            strides = (strides,)
+        self.ndim = len(shape)
+        if len(strides) != self.ndim:
+            raise ValueError('strides not match ndim')
+
+        if queue is None:
+            queue = dpctl.get_current_queue()
+
+        self.shape = tuple(shape)
+        self.strides = tuple(strides)
+        self.dtype = dtype
+        self.size = int(np.prod(self.shape))
+        self.itemsize = dtype.itemsize
+        self.alloc_size = self.size * self.itemsize
+        self.queue = queue
+
+        if self.size > 0:
+            if usm_memory is None:
+                self.usm_memory = dpctl_mem.MemoryUSMShared(self.size * self.itemsize, queue=queue)
+            else:
+                # we should never reach here, refer to comment above
+                self.usm_memory = usm_memory
+        else:
+            self.usm_memory = None
+
+    @property
+    def _numba_type_(self):
+        """
+        Magic attribute expected by Numba to get the numba type that
+        represents this object.
+        """
+        #dtype = numpy_support.from_dtype(self.dtype)
+        return types.Array(self.dtype, self.ndim, 'C')
+
+    def copy_to_device(self, ary):
+        """Copy `ary` to `self`.
+
+        Perform a a host-to-device transfer.
+        """
+        if ary.size == 0:
+            # Nothing to do
+            return
+
+        # We only support copying from NumPy array
+        assert isinstance(ary, np.ndarray)
+
+        # copy to usm_memory
+        self.usm_memory.copy_from_host(ary.tobytes())
+
+    def copy_to_host(self, ary=None):
+        """Copy ``self`` to ``ary`` or create a new Numpy ndarray
+        if ``ary`` is ``None``.
+
+        The transfer is synchronous: the function returns after the copy
+        is finished.
+
+        Always returns the host array.
+        """
+        # a location for the data exists as `hostary`
+        assert self.alloc_size >= 0, "Negative memory size"
+
+        hostary = np.frombuffer(self.usm_memory, dtype=self.dtype).reshape(self.shape)
+        if ary is None:  # destination does not exist
+            if self.alloc_size != 0:
+                return hostary
+        else: # destination does exist, it's `ary`, check it
+            if ary.dtype != self.dtype:
+                raise TypeError('incompatible dtype')
+
+            if ary.shape != self.shape:
+                scalshapes = (), (1,)
+                if not (ary.shape in scalshapes and self.shape in scalshapes):
+                    raise TypeError('incompatible shape; device %s; host %s' %
+                                    (self.shape, ary.shape))
+            if ary.strides != self.strides:
+                scalstrides = (), (self.dtype.itemsize,)
+                if not (ary.strides in scalstrides and
+                                self.strides in scalstrides):
+                    raise TypeError('incompatible strides; device %s; host %s' %
+                                    (self.strides, ary.strides))
+
+            np.copyto(ary, hostary)
+            return ary
+

--- a/numba_dppy/dppy_devicearray.py
+++ b/numba_dppy/dppy_devicearray.py
@@ -139,7 +139,7 @@ class DPPYDeviceArray(object):
         return ary
 
 
-def to_device(ary):
+def to_device(ary, queue=None):
     """Convenience function to create a DPPYDeviceArray from a np.ndarray
     and copy data from ary to the created DPPYDeviceArray.
 
@@ -151,7 +151,7 @@ def to_device(ary):
     if ary is None or not isinstance(ary, np.ndarray):
         raise ValueError("ary has to be a valid np.ndarray")
 
-    da = DPPYDeviceArray(ary.shape, ary.strides, ary.dtype)
+    da = DPPYDeviceArray(ary.shape, ary.strides, ary.dtype, queue=queue)
     da.copy_to_device(ary)
 
     return da

--- a/numba_dppy/examples/dppy_device_array.py
+++ b/numba_dppy/examples/dppy_device_array.py
@@ -29,33 +29,33 @@ def data_parallel_sum(a, b, c):
 def driver(a, b, c, global_size):
     # Get dppy device arrays for input.
     # We can pass kw argument queue to `to_device`. This will
-    # make sure the memory allocated for DPPYDeviceArray is
+    # make sure the memory allocated for DeviceArray is
     # using the passed queue. In the case where the queue
     # is not passed the queue returned by `dpctl.get_current_queue`
     # will be used. The same queue argument can be passed when creating
-    # DPPYDeviceArray as well.
+    # DeviceArray as well.
     da = dppy.to_device(a)
     db = dppy.to_device(b)
 
     # Array `c` is write only. We can use the `to_device`
-    # convenience function or create a DPPYDeviceArray.
+    # convenience function or create a DeviceArray.
     # Using the convenience function will copy the data of
     # the np.ndarray we pass as argument, which is redundant.
-    dc = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+    dc = dppy.DeviceArray(a.shape, a.strides, a.dtype)
 
     data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](da, db, dc)
 
     # copy_to_host will create a ndarray and copy the data from
-    # the DPPYDeviceArray.
+    # the DeviceArray.
     d = dc.copy_to_host()
     assert np.allclose(d, a + b)
 
     # We can also send a np.ndarray and copy the data of the
-    # DPPYDeviceArray in that ndarray.
+    # DeviceArray in that ndarray.
     dc.copy_to_host(c)
     assert np.allclose(c, a + b)
 
-    # We can mix and match DPPYDeviceArray and np.ndarray
+    # We can mix and match DeviceArray and np.ndarray
     data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](c, b, dc)
     e = dc.copy_to_host()
     assert np.allclose(e, c + b)

--- a/numba_dppy/examples/dppy_device_array.py
+++ b/numba_dppy/examples/dppy_device_array.py
@@ -12,10 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
-from timeit import default_timer as time
-
 import sys
 import numpy as np
 import numpy.testing as testing
@@ -38,7 +34,7 @@ def driver(a, b, c, global_size):
     # Array `c` is write only. We can use the `to_device`
     # convenience function or create a DPPYDeviceArray.
     # Using the convenience function will copy the data of
-    # the np.ndarray we pass as argument.
+    # the np.ndarray we pass as argument, which is redundant.
     dc = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
 
     data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](da, db, dc)
@@ -70,6 +66,8 @@ def main():
     if dpctl.has_gpu_queues():
         with dpctl.device_context("opencl:gpu") as gpu_queue:
             driver(a, b, c, global_size)
+
+    print("Done!")
 
 
 if __name__ == "__main__":

--- a/numba_dppy/examples/dppy_device_array.py
+++ b/numba_dppy/examples/dppy_device_array.py
@@ -27,7 +27,13 @@ def data_parallel_sum(a, b, c):
 
 
 def driver(a, b, c, global_size):
-    # Get dppy device arrays for input
+    # Get dppy device arrays for input.
+    # We can pass kw argument queue to `to_device`. This will
+    # make sure the memory allocated for DPPYDeviceArray is
+    # using the passed queue. In the case where the queue
+    # is not passed the queue returned by `dpctl.get_current_queue`
+    # will be used. The same queue argument can be passed when creating
+    # DPPYDeviceArray as well.
     da = dppy.to_device(a)
     db = dppy.to_device(b)
 
@@ -53,7 +59,6 @@ def driver(a, b, c, global_size):
     data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](c, b, dc)
     e = dc.copy_to_host()
     assert np.allclose(e, c + b)
-
 
 
 def main():

--- a/numba_dppy/examples/dppy_device_array.py
+++ b/numba_dppy/examples/dppy_device_array.py
@@ -55,6 +55,7 @@ def driver(a, b, c, global_size):
     assert np.allclose(e, c + b)
 
 
+
 def main():
     global_size = 10
     N = global_size

--- a/numba_dppy/examples/dppy_device_array.py
+++ b/numba_dppy/examples/dppy_device_array.py
@@ -1,0 +1,76 @@
+#! /usr/bin/env python
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+from timeit import default_timer as time
+
+import sys
+import numpy as np
+import numpy.testing as testing
+import numba_dppy as dppy
+import dpctl
+
+
+# Sample Kernel that performs simple element-wise add
+@dppy.kernel
+def data_parallel_sum(a, b, c):
+    i = dppy.get_global_id(0)
+    c[i] = a[i] + b[i]
+
+
+def driver(a, b, c, global_size):
+    # Get dppy device arrays for input
+    da = dppy.to_device(a)
+    db = dppy.to_device(b)
+
+    # Array `c` is write only. We can use the `to_device`
+    # convenience function or create a DPPYDeviceArray.
+    # Using the convenience function will copy the data of
+    # the np.ndarray we pass as argument.
+    dc = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+
+    data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](da, db, dc)
+
+    # copy_to_host will create a ndarray and copy the data from
+    # the DPPYDeviceArray.
+    d = dc.copy_to_host()
+    assert np.allclose(d, a + b)
+
+    # We can also send a np.ndarray and copy the data of the
+    # DPPYDeviceArray in that ndarray.
+    dc.copy_to_host(c)
+    assert np.allclose(c, a + b)
+
+    # We can mix and match DPPYDeviceArray and np.ndarray
+    data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](c, b, dc)
+    e = dc.copy_to_host()
+    assert np.allclose(e, c + b)
+
+
+def main():
+    global_size = 10
+    N = global_size
+
+    a = np.array(np.random.random(N), dtype=np.float32)
+    b = np.array(np.random.random(N), dtype=np.float32)
+    c = np.empty_like(a)
+
+    if dpctl.has_gpu_queues():
+        with dpctl.device_context("opencl:gpu") as gpu_queue:
+            driver(a, b, c, global_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/numba_dppy/tests/test_device_array.py
+++ b/numba_dppy/tests/test_device_array.py
@@ -120,7 +120,6 @@ def test_array_as_arg(filter_str, input_array):
         assert np.allclose(d, c + b)
 
 
-
 @pytest.mark.xfail(strict=True)
 def test_array_as_arg_queue_mismatch():
     @dppy.kernel
@@ -136,7 +135,6 @@ def test_array_as_arg_queue_mismatch():
         # dpctl.device_context.
         da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype, queue=gpu_queue)
         da.copy_to_device(a)
-
 
     with dpctl.device_context("level0:gpu:0") as gpu_queue:
         sample_kernel[a.size, dppy.DEFAULT_LOCAL_SIZE](da)

--- a/numba_dppy/tests/test_device_array.py
+++ b/numba_dppy/tests/test_device_array.py
@@ -63,7 +63,7 @@ def test_array_creation(filter_str, input_array, get_shape):
     a = np.reshape(input_array, get_shape)
 
     with dpctl.device_context(filter_str):
-        da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+        da = dppy.DeviceArray(a.shape, a.strides, a.dtype)
         assert da.shape == a.shape
         assert da.strides == a.strides
         assert da.dtype == a.dtype
@@ -71,20 +71,20 @@ def test_array_creation(filter_str, input_array, get_shape):
         assert da.itemsize == a.dtype.itemsize
 
 
-@pytest.mark.xfail(strict=True)
 def test_array_creation_with_buf(filter_str, input_array, get_shape):
     a = np.reshape(input_array, get_shape)
 
     with dpctl.device_context(filter_str):
         usm_buf = dpctl_mem.MemoryUSMShared(a.size * a.dtype.itemsize)
-        da = dppy.DPPYDeviceArray(shape, strides, dtype, usm_memory=usm_buf)
+        da = dppy.DeviceArray(a.shape, a.strides, a.dtype, usm_memory=usm_buf)
+        assert da.base == usm_buf
 
 
 def test_array_values(filter_str, input_array, get_shape):
     a = np.reshape(input_array, get_shape)
 
     with dpctl.device_context(filter_str):
-        da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+        da = dppy.DeviceArray(a.shape, a.strides, a.dtype)
         da.copy_to_device(a)
         b = da.copy_to_host()
         assert np.array_equal(a, b)
@@ -100,13 +100,13 @@ def test_array_as_arg(filter_str, input_array):
     b = np.ones_like(a)
 
     with dpctl.device_context(filter_str):
-        da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+        da = dppy.DeviceArray(a.shape, a.strides, a.dtype)
         da.copy_to_device(a)
 
-        db = dppy.DPPYDeviceArray(b.shape, b.strides, b.dtype)
+        db = dppy.DeviceArray(b.shape, b.strides, b.dtype)
         db.copy_to_device(b)
 
-        dc = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+        dc = dppy.DeviceArray(a.shape, a.strides, a.dtype)
 
         data_parallel_sum[a.size, dppy.DEFAULT_LOCAL_SIZE](da, db, dc)
 
@@ -133,7 +133,7 @@ def test_array_as_arg_queue_mismatch():
         # Users can explicitly provide SYCL queue, the queue used internally
         # will be the current queue. Current queue is set by the context_manager
         # dpctl.device_context.
-        da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype, queue=gpu_queue)
+        da = dppy.DeviceArray(a.shape, a.strides, a.dtype, queue=gpu_queue)
         da.copy_to_device(a)
 
     with dpctl.device_context("level0:gpu:0") as gpu_queue:
@@ -144,7 +144,7 @@ def test_array_api(filter_str, input_array, get_shape):
     a = np.reshape(input_array, get_shape)
 
     with dpctl.device_context(filter_str) as gpu_queue:
-        da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+        da = dppy.DeviceArray(a.shape, a.strides, a.dtype)
 
         da.copy_to_device(a)
         b = da.copy_to_host()

--- a/numba_dppy/tests/test_device_array.py
+++ b/numba_dppy/tests/test_device_array.py
@@ -121,7 +121,7 @@ def test_array_as_arg(filter_str, input_array):
 
 
 @pytest.mark.xfail(strict=True)
-def test_array_as_arg_queue_mismatch():
+def test_array_as_arg_context_mismatch():
     @dppy.kernel
     def sample_kernel(a):
         i = dppy.get_global_id(0)

--- a/numba_dppy/tests/test_device_array.py
+++ b/numba_dppy/tests/test_device_array.py
@@ -151,7 +151,7 @@ def test_array_api(filter_str, input_array, get_shape):
         c = np.empty_like(a)
         da.copy_to_host(c)
         assert np.array_equal(b, c)
-        assert gpu_queue.equals(da.queue)
+        assert gpu_queue.equals(da.get_queue())
 
 
 def test_to_device(filter_str, input_array, get_shape):

--- a/numba_dppy/tests/test_device_array.py
+++ b/numba_dppy/tests/test_device_array.py
@@ -16,12 +16,13 @@ import numpy as np
 import numba_dppy as dppy
 import pytest
 import dpctl
+import dpctl.memory as dpctl_mem
 from numba_dppy.tests.skip_tests import skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",
-    #"level0:gpu:0",
-    #"opencl:cpu:0",
+    "level0:gpu:0",
+    "opencl:cpu:0",
 ]
 
 
@@ -29,12 +30,14 @@ list_of_filter_strs = [
 def filter_str(request):
     return request.param
 
+
 list_of_dtypes = [
     np.int32,
-    #np.int64,
-    #np.float32,
-    #np.float64,
+    np.int64,
+    np.float32,
+    np.float64,
 ]
+
 
 @pytest.fixture(params=list_of_dtypes)
 def input_array(request):
@@ -45,14 +48,16 @@ def input_array(request):
 
 
 list_of_shape = [
-    (100),
-    #(50, 2),
-    #(10, 5, 2),
+    (100,),
+    (50, 2),
+    (10, 5, 2),
 ]
+
 
 @pytest.fixture(params=list_of_shape)
 def get_shape(request):
     return request.param
+
 
 def test_array_creation(filter_str, input_array, get_shape):
     a = np.reshape(input_array, get_shape)
@@ -65,6 +70,16 @@ def test_array_creation(filter_str, input_array, get_shape):
         assert da.size == a.size
         assert da.itemsize == a.dtype.itemsize
 
+
+@pytest.mark.xfail(strict=True)
+def test_array_creation_with_buf(filter_str, input_array, get_shape):
+    a = np.reshape(input_array, get_shape)
+
+    with dpctl.device_context(filter_str):
+        usm_buf = dpctl_mem.MemoryUSMShared(a.size * a.dtype.itemsize)
+        da = dppy.DPPYDeviceArray(shape, strides, dtype, usm_memory=usm_buf)
+
+
 def test_array_values(filter_str, input_array, get_shape):
     a = np.reshape(input_array, get_shape)
 
@@ -74,3 +89,45 @@ def test_array_values(filter_str, input_array, get_shape):
         b = da.copy_to_host()
         assert np.array_equal(a, b)
 
+
+def test_array_as_arg(filter_str, input_array):
+    @dppy.kernel
+    def data_parallel_sum(a, b, c):
+        i = dppy.get_global_id(0)
+        c[i] = a[i] + b[i]
+
+    a = input_array
+    b = np.ones_like(a)
+
+    with dpctl.device_context(filter_str):
+        da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+        da.copy_to_device(a)
+
+        db = dppy.DPPYDeviceArray(b.shape, b.strides, b.dtype)
+        db.copy_to_device(b)
+
+        dc = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+
+        data_parallel_sum[a.size, dppy.DEFAULT_LOCAL_SIZE](da, db, dc)
+
+        c = dc.copy_to_host()
+
+        assert np.allclose(c, a + b)
+
+        # We can mix device array and ndarray
+        data_parallel_sum[c.size, dppy.DEFAULT_LOCAL_SIZE](c, db, dc)
+        d = dc.copy_to_host()
+        assert np.allclose(d, c + b)
+
+
+def test_array_api(filter_str, input_array, get_shape):
+    a = np.reshape(input_array, get_shape)
+
+    with dpctl.device_context(filter_str):
+        da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+
+        da.copy_to_device(a)
+        b = da.copy_to_host()
+        c = np.empty_like(a)
+        da.copy_to_host(c)
+        assert np.array_equal(b, c)

--- a/numba_dppy/tests/test_device_array.py
+++ b/numba_dppy/tests/test_device_array.py
@@ -1,0 +1,76 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import numba_dppy as dppy
+import pytest
+import dpctl
+from numba_dppy.tests.skip_tests import skip_test
+
+list_of_filter_strs = [
+    "opencl:gpu:0",
+    #"level0:gpu:0",
+    #"opencl:cpu:0",
+]
+
+
+@pytest.fixture(params=list_of_filter_strs)
+def filter_str(request):
+    return request.param
+
+list_of_dtypes = [
+    np.int32,
+    #np.int64,
+    #np.float32,
+    #np.float64,
+]
+
+@pytest.fixture(params=list_of_dtypes)
+def input_array(request):
+    # The size of input and out arrays to be used
+    N = 100
+    a = np.array(np.random.random(N), request.param)
+    return a
+
+
+list_of_shape = [
+    (100),
+    #(50, 2),
+    #(10, 5, 2),
+]
+
+@pytest.fixture(params=list_of_shape)
+def get_shape(request):
+    return request.param
+
+def test_array_creation(filter_str, input_array, get_shape):
+    a = np.reshape(input_array, get_shape)
+
+    with dpctl.device_context(filter_str):
+        da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+        assert da.shape == a.shape
+        assert da.strides == a.strides
+        assert da.dtype == a.dtype
+        assert da.size == a.size
+        assert da.itemsize == a.dtype.itemsize
+
+def test_array_values(filter_str, input_array, get_shape):
+    a = np.reshape(input_array, get_shape)
+
+    with dpctl.device_context(filter_str):
+        da = dppy.DPPYDeviceArray(a.shape, a.strides, a.dtype)
+        da.copy_to_device(a)
+        b = da.copy_to_host()
+        assert np.array_equal(a, b)
+


### PR DESCRIPTION
This PR introduces `DPPYDeviceArray` class in Numba_dppy. This will give users: 

-  `class` to represent arrays in device.
- Will allow Numba_dppy to implement interface Numba requires for functionality such as `@vectorize`. See [here](https://github.com/numba/numba/blob/master/numba/np/ufunc/deviceufunc.py#L308).