### PR TITLE
Restrict dpnp version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.52.*
         - dpctl 0.7.*
-        - dpnp >=0.5.1  # [linux]
+        - dpnp >=0.5.1,<0.6.*  # [linux]
         - wheel
     run:
         - python
@@ -29,7 +29,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp >=0.5.1  # [linux]
+        - dpnp >=0.5.1,<0.6.*  # [linux]
 
 test:
   requires:


### PR DESCRIPTION
This PR will restrict the dpnp version between >=0.5.1 and <0.6.*