### PR TITLE
Fix dpnp version restriction in conda recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.52.*
         - dpctl 0.7.*
-        - dpnp >=0.5.1,<0.6.0a0  # [linux]
+        - dpnp >=0.5.1,<0.6.0dev  # [linux]
         - wheel
     run:
         - python
@@ -29,7 +29,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp >=0.5.1,<0.6.0a0  # [linux]
+        - dpnp >=0.5.1,<0.6.0dev  # [linux]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.52.*
         - dpctl 0.7.*
-        - dpnp >=0.5.1  # [linux ans py==37]
+        - dpnp >=0.5.1  # [linux and py==37]
         - wheel
     run:
         - python
@@ -29,7 +29,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp >=0.5.1  # [linux ans py==37]
+        - dpnp >=0.5.1  # [linux and py==37]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.52.*
         - dpctl 0.7.*
-        - dpnp >=0.5.1,<0.6.0dev  # [linux and py==37]
+        - dpnp >=0.5.1,<0.6*  # [linux and py==37]
         - wheel
     run:
         - python
@@ -29,7 +29,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp >=0.5.1,<0.6.0dev  # [linux and py==37]
+        - dpnp >=0.5.1,<0.6*  # [linux and py==37]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.52.*
         - dpctl 0.7.*
-        - dpnp >=0.5.1  # [linux and py==37]
+        - dpnp >=0.5.1,<0.6.0dev  # [linux and py==37]
         - wheel
     run:
         - python
@@ -29,7 +29,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp >=0.5.1  # [linux and py==37]
+        - dpnp >=0.5.1,<0.6.0dev  # [linux and py==37]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.52.*
         - dpctl 0.7.*
-        - dpnp >=0.5.1,<0.6.*  # [linux]
+        - dpnp >=0.5.1,<0.6.0a0  # [linux]
         - wheel
     run:
         - python
@@ -29,7 +29,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp >=0.5.1,<0.6.*  # [linux]
+        - dpnp >=0.5.1,<0.6.0a0  # [linux]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.52.*
         - dpctl 0.7.*
-        - dpnp >=0.5.1,<0.6.0dev  # [linux]
+        - dpnp >=0.5.1  # [linux ans py==37]
         - wheel
     run:
         - python
@@ -29,7 +29,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp >=0.5.1,<0.6.0dev  # [linux]
+        - dpnp >=0.5.1  # [linux ans py==37]
 
 test:
   requires:


### PR DESCRIPTION
Improves #344.
The problem with Python 3.8 is in integration with DPNP. So now I disable DPNP for Python 3.8 and downgrade DPNP to 0.5.1 on Python 3.7.
Enable it back in #348.