### PR TITLE
Add automerge main to gold/2021

### DIFF
--- a/.github/workflows/merge-main-to-gold_2021.yml
+++ b/.github/workflows/merge-main-to-gold_2021.yml
@@ -1,0 +1,23 @@
+name: Merge main to gold/2021
+
+on:
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  main-to-gold_2021:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: |
+          git config user.name "Sergey Pokhodenko"
+          git config user.email sergey.pokhodenko@intel.com
+          git checkout gold/2021
+          git merge main
+          git push


### PR DESCRIPTION
We release packages from gold/2021.
This PR merge each commit in main branch to gold/2021 to keep it up to date.