### PR TITLE
Update license in conda recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,9 +37,9 @@ test:
 
 about:
     home: https://github.com/IntelPython/numba-dppy
-    license: BSD-2-Clause
-    license_file: LICENSE
     summary: "Numba extension for Intel CPU and GPU backend"
+    license: Apache-2.0
+    license_file: LICENSE
     description: |
         <strong>LEGAL NOTICE: Use of this software package is subject to the
         software license agreement (as set forth above, in the license section of
@@ -47,7 +47,7 @@ about:
         disclaimers or license terms for third party or open source software
         included in or with the software.</strong>
         <br/><br/>
-        EULA: <a href="https://opensource.org/licenses/BSD-2-Clause" target="_blank">BSD-2-Clause</a>
+        EULA: <a href="https://opensource.org/licenses/Apache-2.0" target="_blank">Apache-2.0</a>
         <br/><br/>
 
 extra:


### PR DESCRIPTION
Replace license in conda recipe from BSD-2 to Apache-2.0 as Apache-2.0 is main license for numba-dppy.