### PR TITLE
Print traceback when DPPY lowering failed.

### DIFF
--- a/numba_dppy/tests/test_controllable_fallback.py
+++ b/numba_dppy/tests/test_controllable_fallback.py
@@ -48,9 +48,7 @@ class TestDPPYFallback(unittest.TestCase):
         numba_dppy.compiler.DEBUG = 0
 
         np.testing.assert_array_equal(dppy_fallback_true, ref_result)
-        self.assertIn(
-            "Failed to lower parfor to the specified SYCL device", str(w[-1].message)
-        )
+        self.assertIn("Failed to offload parfor", str(w[-1].message))
 
     @unittest.expectedFailure
     def test_dppy_fallback_false(self):
@@ -81,10 +79,7 @@ class TestDPPYFallback(unittest.TestCase):
             numba_dppy.compiler.DEBUG = 0
 
             not np.testing.assert_array_equal(dppy_fallback_false, ref_result)
-            self.assertNotIn(
-                "Failed to lower parfor to the specified SYCL device",
-                str(w[-1].message),
-            )
+            self.assertNotIn("Failed to offload parfor", str(w[-1].message))
 
 
 if __name__ == "__main__":

--- a/numba_dppy/tests/test_dppy_fallback.py
+++ b/numba_dppy/tests/test_dppy_fallback.py
@@ -46,9 +46,7 @@ class TestDPPYFallback(unittest.TestCase):
         ref_result = inner_call_fallback()
 
         np.testing.assert_array_equal(dppy_result, ref_result)
-        self.assertIn(
-            "Failed to lower parfor to the specified SYCL device", str(w[-1].message)
-        )
+        self.assertIn("Failed to offload parfor ", str(w[-1].message))
 
     def test_dppy_fallback_reductions(self):
         def reduction(a):
@@ -67,9 +65,7 @@ class TestDPPYFallback(unittest.TestCase):
         ref_result = reduction(a)
 
         np.testing.assert_array_equal(dppy_result, ref_result)
-        self.assertIn(
-            "Failed to lower parfor to the specified SYCL device", str(w[-1].message)
-        )
+        self.assertIn("Failed to offload parfor ", str(w[-1].message))
 
 
 if __name__ == "__main__":

--- a/numba_dppy/tests/test_parfor_lower_message.py
+++ b/numba_dppy/tests/test_parfor_lower_message.py
@@ -43,7 +43,7 @@ class TestParforMessage(unittest.TestCase):
                 jitted()
 
             dppy.compiler.DEBUG = 0
-            self.assertTrue("Parfor lowered to specified SYCL device" in got.getvalue())
+            self.assertTrue("Parfor offloaded " in got.getvalue())
 
 
 if __name__ == "__main__":

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -46,9 +46,7 @@ class TestWithDPPYContext(unittest.TestCase):
         func(expected)
 
         np.testing.assert_array_equal(expected, got_gpu)
-        self.assertTrue(
-            "Parfor lowered to specified SYCL device" in got_gpu_message.getvalue()
-        )
+        self.assertTrue("Parfor offloaded to opencl:gpu" in got_gpu_message.getvalue())
 
     @unittest.skipIf(not _helper.has_cpu_queues(), "No CPU platforms available")
     def test_with_dppy_context_cpu(self):
@@ -73,9 +71,7 @@ class TestWithDPPYContext(unittest.TestCase):
         func(expected)
 
         np.testing.assert_array_equal(expected, got_cpu)
-        self.assertTrue(
-            "Parfor lowered to specified SYCL device" in got_cpu_message.getvalue()
-        )
+        self.assertTrue("Parfor offloaded to opencl:cpu" in got_cpu_message.getvalue())
 
     @unittest.skipIf(not _helper.has_gpu_queues(), "No GPU platforms available")
     def test_with_dppy_context_target(self):


### PR DESCRIPTION
Currently, when parfor lowering fails and we fall back to the default CPU lowerer for a parfor a very skimpy message is printed. The PR adds the traceback to get some more information on why and where DPPY lowering failed.