### PR TITLE
Fix SPIR-V validation

### DIFF
--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -31,12 +31,11 @@ import numpy as np
 
 from . import spirv_generator
 
-import os
 from numba.core.compiler import DefaultPassBuilder, CompilerBase
 from numba_dppy.dppy_parfor_diagnostics import ExtendedParforDiagnostics
+from numba_dppy.config import DEBUG
 
 
-DEBUG = os.environ.get("NUMBA_DPPY_DEBUG", None)
 _NUMBA_DPPY_READ_ONLY = "read_only"
 _NUMBA_DPPY_WRITE_ONLY = "write_only"
 _NUMBA_DPPY_READ_WRITE = "read_write"

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -61,3 +61,6 @@ SPIRV_VAL = _readenv("NUMBA_DPPY_SPIRV_VAL", int, 0)
 OFFLOAD_DIAGNOSTICS = _readenv("NUMBA_DPPY_OFFLOAD_DIAGNOSTICS", int, 0)
 
 FALLBACK_ON_CPU = _readenv("NUMBA_DPPY_FALLBACK_ON_CPU", int, 1)
+
+# Emit debug info
+DEBUG = os.environ.get("NUMBA_DPPY_DEBUG", None)

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -86,8 +86,9 @@ class CmdLine(object):
         # Get optimization level from NUMBA_OPT
         opt_level_option = f"-O{config.OPT}"
 
+        # spirv-debug-info-version flag is for generating right ocl debug info name
         check_call(["opt", opt_level_option, "-o", ipath + ".bc", ipath])
-        check_call(["llvm-spirv", "-o", opath, ipath + ".bc"])
+        check_call(["llvm-spirv", "--spirv-debug-info-version=ocl-100", "-o", opath, ipath + ".bc"])
 
         if dppy_config.SAVE_IR_FILES == 0:
             os.unlink(ipath + ".bc")

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -85,18 +85,20 @@ class CmdLine(object):
 
         # Get optimization level from NUMBA_OPT
         opt_level_option = f"-O{config.OPT}"
-
-        # spirv-debug-info-version flag is for generating right ocl debug info name
-        check_call(["opt", opt_level_option, "-o", ipath + ".bc", ipath])
-        check_call(
-            [
+        if dppy_config.DEBUG:
+            llvm_spirv_command = [
                 "llvm-spirv",
                 "--spirv-debug-info-version=ocl-100",
                 "-o",
                 opath,
                 ipath + ".bc",
             ]
-        )
+        else:
+            llvm_spirv_command = ["llvm-spirv", "-o", opath, ipath + ".bc"]
+
+        # spirv-debug-info-version flag is for generating right ocl debug info name
+        check_call(["opt", opt_level_option, "-o", ipath + ".bc", ipath])
+        check_call(llvm_spirv_command)
 
         if dppy_config.SAVE_IR_FILES == 0:
             os.unlink(ipath + ".bc")

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -88,7 +88,15 @@ class CmdLine(object):
 
         # spirv-debug-info-version flag is for generating right ocl debug info name
         check_call(["opt", opt_level_option, "-o", ipath + ".bc", ipath])
-        check_call(["llvm-spirv", "--spirv-debug-info-version=ocl-100", "-o", opath, ipath + ".bc"])
+        check_call(
+            [
+                "llvm-spirv",
+                "--spirv-debug-info-version=ocl-100",
+                "-o",
+                opath,
+                ipath + ".bc",
+            ]
+        )
 
         if dppy_config.SAVE_IR_FILES == 0:
             os.unlink(ipath + ".bc")

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -85,20 +85,11 @@ class CmdLine(object):
 
         # Get optimization level from NUMBA_OPT
         opt_level_option = f"-O{config.OPT}"
-        if dppy_config.DEBUG:
-            llvm_spirv_command = [
-                "llvm-spirv",
-                "--spirv-debug-info-version=ocl-100",
-                "-o",
-                opath,
-                ipath + ".bc",
-            ]
-        else:
-            llvm_spirv_command = ["llvm-spirv", "-o", opath, ipath + ".bc"]
-
         # spirv-debug-info-version flag is for generating right ocl debug info name
+        ocl_debug_flag = ["--spirv-debug-info-version=ocl-100"] if dppy_config.DEBUG else []
+
         check_call(["opt", opt_level_option, "-o", ipath + ".bc", ipath])
-        check_call(llvm_spirv_command)
+        check_call(["llvm-spirv", *ocl_debug_flag, "-o", opath, ipath + ".bc"])
 
         if dppy_config.SAVE_IR_FILES == 0:
             os.unlink(ipath + ".bc")

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -85,11 +85,13 @@ class CmdLine(object):
 
         # Get optimization level from NUMBA_OPT
         opt_level_option = f"-O{config.OPT}"
-        # spirv-debug-info-version flag is for generating right ocl debug info name
-        ocl_debug_flag = ["--spirv-debug-info-version=ocl-100"] if dppy_config.DEBUG else []
+
+        llvm_spirv_flags = []
+        if dppy_config.DEBUG:
+            llvm_spirv_flags.append("--spirv-debug-info-version=ocl-100")
 
         check_call(["opt", opt_level_option, "-o", ipath + ".bc", ipath])
-        check_call(["llvm-spirv", *ocl_debug_flag, "-o", opath, ipath + ".bc"])
+        check_call(["llvm-spirv", *llvm_spirv_flags, "-o", opath, ipath + ".bc"])
 
         if dppy_config.SAVE_IR_FILES == 0:
             os.unlink(ipath + ".bc")


### PR DESCRIPTION
This PR only affects spirv validation (NUMBA_DPPY_SPIRV_VAL=1). It resolves the problem with not appropriate debug instruction name for offloading with ocl.
If we don't add "--spirv-debug-info-version=ocl-100" flag to spirv generating, we get the following error:
`error: line 9: Invalid extended instruction import 'SPIRV.debug'`

Add OpenCL.DebugInfo.100 as flag to SPIRV generator according to specification: https://www.khronos.org/registry/spir-v/specs/unified1/OpenCL.DebugInfo.100.html
