### PR TITLE
Update to DPNP 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://intelpython.github.io/dpnp/
 
 * numba 0.52.* (IntelPython/numba)
 * dpctl 0.7.*
-* dpnp >=0.5.1 (optional)
+* dpnp >=0.6.1 (optional)
 * llvm-spirv (SPIRV generation from LLVM IR)
 * llvmdev (LLVM IR generation)
 * spirv-tools

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://intelpython.github.io/dpnp/
 
 * numba 0.52.* (IntelPython/numba)
 * dpctl 0.7.*
-* dpnp >=0.6.1 (optional)
+* dpnp 0.6.* (optional)
 * llvm-spirv (SPIRV generation from LLVM IR)
 * llvmdev (LLVM IR generation)
 * spirv-tools

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.52.*
         - dpctl 0.7.*
-        - dpnp >=0.6.1,<0.7*  # [linux and py==37]
+        - dpnp >=0.6.1*,<0.7*  # [linux and py==37]
         - wheel
     run:
         - python
@@ -29,7 +29,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp >=0.6.1,<0.7*  # [linux and py==37]
+        - dpnp >=0.6.1*,<0.7*  # [linux and py==37]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.52.*
         - dpctl 0.7.*
-        - dpnp >=0.5.1,<0.6*  # [linux and py==37]
+        - dpnp >=0.6.1,<0.7*  # [linux and py==37]
         - wheel
     run:
         - python
@@ -29,7 +29,7 @@ requirements:
         - spirv-tools
         - llvm-spirv
         - llvmdev
-        - dpnp >=0.5.1,<0.6*  # [linux and py==37]
+        - dpnp >=0.6.1,<0.7*  # [linux and py==37]
 
 test:
   requires:

--- a/numba_dppy/dpnp_glue/dpnp_statisticsimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_statisticsimpl.py
@@ -154,11 +154,10 @@ def dpnp_mean_impl(a):
     ret_type = types.void
     """
     dpnp source:
-    https://github.com/IntelPython/dpnp/blob/0.4.0/dpnp/backend/custom_kernels_statistics.cpp#L169
+    https://github.com/IntelPython/dpnp/blob/0.6.1dev/dpnp/backend/kernels/dpnp_krnl_statistics.cpp#L185
 
     Function declaration:
-    void custom_mean_c(void* array1_in, void* result1, const size_t* shape,
-                       size_t ndim, const size_t* axis, size_t naxis)
+    void dpnp_mean_c(void* array1_in, void* result1, const size_t* shape, size_t ndim, const size_t* axis, size_t naxis)
 
     We are using void * in case of size_t * as Numba currently does not have
     any type to represent size_t *. Since, both the types are pointers,
@@ -194,7 +193,9 @@ def dpnp_mean_impl(a):
         out = np.empty(1, dtype=res_dtype)
         out_usm = dpctl_functions.malloc_shared(out.itemsize, sycl_queue)
 
-        dpnp_func(a_usm, out_usm, a.shapeptr, a.ndim, a.shapeptr, a.ndim)
+        axis, naxis = 0, 0
+
+        dpnp_func(a_usm, out_usm, a.shapeptr, a.ndim, axis, naxis)
 
         dpctl_functions.queue_memcpy(
             sycl_queue, out.ctypes, out_usm, out.size * out.itemsize

--- a/numba_dppy/dpnp_glue/dpnp_transcendentalsimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_transcendentalsimpl.py
@@ -106,12 +106,29 @@ def dpnp_prod_impl(a):
     ret_type = types.void
     """
     dpnp source:
-    https://github.com/IntelPython/dpnp/blob/0.4.0/dpnp/backend/custom_kernels_reduction.cpp#L83
+    https://github.com/IntelPython/dpnp/blob/0.6.1dev/dpnp/backend/kernels/dpnp_krnl_reduction.cpp#L129
 
     Function declaration:
-    void custom_prod_c(void* array1_in, void* result1, size_t size)
+    void dpnp_prod_c(void* result_out,
+                     const void* input_in,
+                     const size_t* input_shape,
+                     const size_t input_shape_ndim,
+                     const long* axes,
+                     const size_t axes_ndim,
+                     const void* initial, // type must be _DataType_output
+                     const long* where)
     """
-    sig = signature(ret_type, types.voidptr, types.voidptr, types.intp)
+    sig = signature(
+        ret_type,
+        types.voidptr,  # void* result_out,
+        types.voidptr,  # const void* input_in,
+        types.voidptr,  # const size_t* input_shape,
+        types.intp,  # const size_t input_shape_ndim,
+        types.voidptr,  # const long* axes,
+        types.intp,  # const long* axes,
+        types.voidptr,  # const void* initial, // type must be _DataType_output
+        types.voidptr,  # const long* where)
+    )
     dpnp_func = dpnp_ext.dpnp_func("dpnp_" + name, [a.dtype.name, "NONE"], sig)
 
     PRINT_DEBUG = dpnp_lowering.DEBUG

--- a/numba_dppy/dpnp_glue/dpnp_transcendentalsimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_transcendentalsimpl.py
@@ -34,7 +34,11 @@ def common_impl(a, out, dpnp_func, print_debug):
 
     out_usm = dpctl_functions.malloc_shared(a.itemsize, sycl_queue)
 
-    dpnp_func(a_usm, out_usm, a.size)
+    initial = np.zeros(1, dtype=a.dtype)
+    axes, axes_ndim = 0, 0
+    where = 0
+
+    dpnp_func(out_usm, a_usm, a.shapeptr, a.ndim, axes, axes_ndim, initial.ctypes, where)
 
     dpctl_functions.queue_memcpy(
         sycl_queue, out.ctypes, out_usm, out.size * out.itemsize
@@ -43,7 +47,7 @@ def common_impl(a, out, dpnp_func, print_debug):
     dpctl_functions.free_with_queue(a_usm, sycl_queue)
     dpctl_functions.free_with_queue(out_usm, sycl_queue)
 
-    dpnp_ext._dummy_liveness_func([out.size])
+    dpnp_ext._dummy_liveness_func([a.size, out.size])
 
     if print_debug:
         print("dpnp implementation")
@@ -57,13 +61,24 @@ def dpnp_sum_impl(a):
     ret_type = types.void
     """
     dpnp source:
-    https://github.com/IntelPython/dpnp/blob/0.4.0/dpnp/backend/custom_kernels_reduction.cpp#L39
+    https://github.com/IntelPython/dpnp/blob/0.6.1dev/dpnp/backend/kernels/dpnp_krnl_reduction.cpp#L59
 
     Function declaration:
-    void custom_sum_c(void* array1_in, void* result1, size_t size)
+    void dpnp_sum_c(void* result_out,
+                    const void* input_in,
+                    const size_t* input_shape,
+                    const size_t input_shape_ndim,
+                    const long* axes,
+                    const size_t axes_ndim,
+                    const void* initial,
+                    const long* where)
 
     """
-    sig = signature(ret_type, types.voidptr, types.voidptr, types.intp)
+    sig = signature(ret_type,
+                    types.voidptr, types.voidptr,
+                    types.voidptr, types.intp,
+                    types.voidptr, types.intp,
+                    types.voidptr, types.voidptr)
     dpnp_func = dpnp_ext.dpnp_func("dpnp_" + name, [a.dtype.name, "NONE"], sig)
 
     PRINT_DEBUG = dpnp_lowering.DEBUG

--- a/numba_dppy/dpnp_glue/dpnp_transcendentalsimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_transcendentalsimpl.py
@@ -34,11 +34,11 @@ def common_impl(a, out, dpnp_func, print_debug):
 
     out_usm = dpctl_functions.malloc_shared(a.itemsize, sycl_queue)
 
-    initial = np.zeros(1, dtype=a.dtype)
     axes, axes_ndim = 0, 0
+    initial = 0
     where = 0
 
-    dpnp_func(out_usm, a_usm, a.shapeptr, a.ndim, axes, axes_ndim, initial.ctypes, where)
+    dpnp_func(out_usm, a_usm, a.shapeptr, a.ndim, axes, axes_ndim, initial, where)
 
     dpctl_functions.queue_memcpy(
         sycl_queue, out.ctypes, out_usm, out.size * out.itemsize
@@ -74,11 +74,17 @@ def dpnp_sum_impl(a):
                     const long* where)
 
     """
-    sig = signature(ret_type,
-                    types.voidptr, types.voidptr,
-                    types.voidptr, types.intp,
-                    types.voidptr, types.intp,
-                    types.voidptr, types.voidptr)
+    sig = signature(
+        ret_type,
+        types.voidptr,  # void* result_out,
+        types.voidptr,  # const void* input_in,
+        types.voidptr,  # const size_t* input_shape,
+        types.intp,  # const size_t input_shape_ndim,
+        types.voidptr,  # const long* axes,
+        types.intp,  # const size_t axes_ndim,
+        types.voidptr,  # const void* initial,
+        types.voidptr,  # const long* where)
+    )
     dpnp_func = dpnp_ext.dpnp_func("dpnp_" + name, [a.dtype.name, "NONE"], sig)
 
     PRINT_DEBUG = dpnp_lowering.DEBUG


### PR DESCRIPTION
This PR only unblock DPNP 0.6.
It does not update to new features of DPNP 0.6.


Unblock functions (API changed in DPNP 0.6):
- [x] sum #356 #358
- [x] prod
- [x] dot
- [x] cross (not used)
- [x] correlate (not used)
- [x] floor_divide (not used)
- [x] reminder (not used)
- [x] bitwise (not used)
- [x] mean

Update new features:
- [ ] do not pass a.shapeptr and a.ndim to axis (i.e. see mean)
- [ ] sum (axis, initial)
- [ ] prod (axis, initial)
- [ ] dot
- [ ] cross (not used)
- [ ] correlate (not used)
- [ ] floor_divide (not used)
- [ ] reminder (not used)
- [ ] bitwise (not used)
- [ ] mean (axis)
