### PR TITLE
Override get_ufunc_info in DPPYTargetContext

### DIFF
--- a/numba_dppy/target.py
+++ b/numba_dppy/target.py
@@ -329,6 +329,10 @@ class DPPYTargetContext(BaseContext):
         ptras = llvmir.PointerType(src.type.pointee, addrspace=addrspace)
         return builder.addrspacecast(src, ptras)
 
+    # Overrides
+    def get_ufunc_info(self, ufunc_key):
+        return self.ufunc_db[ufunc_key]
+
 
 def set_dppy_kernel(fn):
     """


### PR DESCRIPTION
This PR adds `get_unfunc_info` to DPPYTargetContext. Without this function we can not offload `Numpy ufuncs` inside `@njit` decorated function. This was implemented in Numba 0.54.rc which was backported in Intel Numba [release0.53-patched](https://github.com/IntelPython/numba/tree/release0.53-patched).