### PR TITLE
Improve error reporting when searching for dpctl.

### DIFF
--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -16,6 +16,14 @@ import os
 import warnings
 from packaging import version
 
+class DpctlMinimumVersionRequiredError(Exception):
+    """
+    A ``DpctlMinimumVersionRequiredError`` indicates that the version of dpctl
+    does not satisfy the minimum version requirement.
+
+    """
+    pass
+
 # Check for dpctl 0.7.0 or higher on the system.
 _dpctl_found = False
 try:
@@ -24,10 +32,9 @@ try:
     # Versions of dpctl lower than 0.7.0 are not compatible with current main
     # of numba_dppy.
     if version.parse(dpctl.__version__) < version.parse("0.7.0"):
-        msg = "numba_dppy requires dpctl 0.7.0 or higher."
-        warnings.warn(msg, UserWarning)
+        raise DpctlMinimumVersionRequiredError
 
-    # For the Numba_dppy extension to work we should have at least one
+    # For the Numba_dppy extension to work, we should have at least one
     # non-host SYCL device installed.
     # FIXME: In future, we should support just the host device.
     if not dpctl.select_default_device().is_host:
@@ -36,6 +43,9 @@ try:
         msg = "dpctl could not find any non-host SYCL device on the system. "
         msg += "A non-host SYCL device is required to use numba_dppy."
         warnings.warn(msg, UserWarning)
+except DpctlMinimumVersionRequiredError:
+    msg = "numba_dppy requires dpctl 0.7.0 or higher."
+    warnings.warn(msg, UserWarning)
 except:
     msg = "Please install dpctl 0.7.0 or higher."
     warnings.warn(msg, UserWarning)

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -16,13 +16,16 @@ import os
 import warnings
 from packaging import version
 
+
 class DpctlMinimumVersionRequiredError(Exception):
     """
     A ``DpctlMinimumVersionRequiredError`` indicates that the version of dpctl
     does not satisfy the minimum version requirement.
 
     """
+
     pass
+
 
 # Check for dpctl 0.7.0 or higher on the system.
 _dpctl_found = False

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -13,20 +13,36 @@
 # limitations under the License.
 
 import os
+import warnings
+from packaging import version
 
-
+# Check for dpctl 0.7.0 or higher on the system.
+_dpctl_found = False
 try:
     import dpctl
 
-    dppy_present = False
-    try:
-        # For the extension to work we should have at least one
-        # non-host SYCL device.
-        dppy_present = not dpctl.select_default_device().is_host
-    except ValueError:
-        dppy_present = False
+    # Versions of dpctl lower than 0.7.0 are not compatible with current main
+    # of numba_dppy.
+    if version.parse(dpctl.__version__) < version.parse("0.7.0"):
+        msg = "numba_dppy requires dpctl 0.7.0 or higher."
+        warnings.warn(msg, UserWarning)
+
+    # For the Numba_dppy extension to work we should have at least one
+    # non-host SYCL device installed.
+    # FIXME: In future, we should support just the host device.
+    if not dpctl.select_default_device().is_host:
+        _dpctl_found = True
+    else:
+        msg = "dpctl could not find any non-host SYCL device on the system. "
+        msg += "A non-host SYCL device is required to use numba_dppy."
+        warnings.warn(msg, UserWarning)
 except:
-    dppy_present = False
+    msg = "Please install dpctl 0.7.0 or higher."
+    warnings.warn(msg, UserWarning)
+
+# Set this config flag based on if dpctl is found or not. The config flags is
+# used elsewhere inside Numba.
+dppy_present = _dpctl_found
 
 
 def _readenv(name, ctor, default):


### PR DESCRIPTION
The PR improves the user warnings that are printed when a required version of `dpctl` is not found. There are three things that are checked for `numba_dppy` to set the `dppy_found` flag:

1. `import dpctl` does not raise an error.
2. The `dpctl` version is at least 0.7.0.
3. The `dpctl.select_default_device().is_host` returns `False`, *i.e.*, there is at least one non-host SYCL device.

Closes #219.