### PR TITLE
Remove kernel wrapper function

### DIFF
--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -145,9 +145,9 @@ def compile_kernel(sycl_queue, pyfunc, args, access_types, debug=False):
 
     cres = compile_with_dppy(pyfunc, None, args, debug=debug)
     kernel = cres.library.get_function(cres.fndesc.llvm_func_name)
-    breakpoint()
-    # target.set_dppy_kernel(kernel)
+
     # kernel = cres.target_context.prepare_ocl_kernel(func, cres.signature.args)
+
     # A reference to the target context is stored in the DPPYKernel to
     # reference the context later in code generation. For example, we link
     # the kernel object with a spir_func defining atomic operations only

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import copy
-from collections import namedtuple
 
 from .dppy_passbuilder import DPPYPassBuilder
 from numba.core.typing.templates import ConcreteTemplate
@@ -28,7 +27,7 @@ import dpctl.memory as dpctl_mem
 import dpctl.program as dpctl_prog
 import numpy as np
 
-from . import spirv_generator, target
+from . import spirv_generator
 
 from numba.core.compiler import DefaultPassBuilder, CompilerBase
 from numba_dppy.dppy_parfor_diagnostics import ExtendedParforDiagnostics
@@ -43,7 +42,7 @@ _NUMBA_DPPY_READ_WRITE = "read_write"
 
 def _raise_no_device_found_error():
     error_message = (
-        "No OpenCL device specified. "
+        "No SYCL device specified. "
         "Usage : jit_fn[device, globalsize, localsize](...)"
     )
     raise ValueError(error_message)
@@ -147,7 +146,7 @@ def compile_kernel(sycl_queue, pyfunc, args, access_types, debug=False):
     cres = compile_with_dppy(pyfunc, None, args, debug=debug)
     kernel = cres.library.get_function(cres.fndesc.llvm_func_name)
     breakpoint()
-    target.set_dppy_kernel(kernel)
+    # target.set_dppy_kernel(kernel)
     # kernel = cres.target_context.prepare_ocl_kernel(func, cres.signature.args)
     # A reference to the target context is stored in the DPPYKernel to
     # reference the context later in code generation. For example, we link

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -130,7 +130,6 @@ def compile_with_dppy(pyfunc, return_type, args, debug):
     else:
         assert 0
     # Linking depending libraries
-    # targetctx.link_dependencies(cres.llvm_module, cres.target_context.linking)
     library = cres.library
     library.finalize()
 
@@ -179,11 +178,8 @@ def compile_kernel_parfor(sycl_queue, func_ir, args, args_with_addrspaces, debug
         print("compile_kernel_parfor signature", cres.signature.args)
         for a in cres.signature.args:
             print(a, type(a))
-    #            if isinstance(a, types.npytypes.Array):
-    #                print("addrspace:", a.addrspace)
 
     kernel = cres.target_context.prepare_ocl_kernel(func, cres.signature.args)
-    # kernel = cres.target_context.prepare_ocl_kernel(func, args_with_addrspaces)
     oclkern = DPPYKernel(
         context=cres.target_context,
         sycl_queue=sycl_queue,
@@ -191,7 +187,7 @@ def compile_kernel_parfor(sycl_queue, func_ir, args, args_with_addrspaces, debug
         name=kernel.name,
         argtypes=args_with_addrspaces,
     )
-    # argtypes=cres.signature.args)
+
     return oclkern
 
 

--- a/numba_dppy/dppy_array_type.py
+++ b/numba_dppy/dppy_array_type.py
@@ -84,8 +84,8 @@ class DPPYArrayModel(StructModel):
     def __init__(self, dmm, fe_type):
         ndim = fe_type.ndim
         members = [
-            ("meminfo", types.MemInfoPointer(fe_type.dtype)),
-            ("parent", types.pyobject),
+            ("meminfo", types.CPointer(fe_type.dtype, addrspace=fe_type.addrspace)),
+            ("parent", types.CPointer(fe_type.dtype, addrspace=fe_type.addrspace)),
             ("nitems", types.intp),
             ("itemsize", types.intp),
             ("data", types.CPointer(fe_type.dtype, addrspace=fe_type.addrspace)),

--- a/numba_dppy/dppy_lowerer.py
+++ b/numba_dppy/dppy_lowerer.py
@@ -56,7 +56,11 @@ from numba_dppy.driver import KernelLaunchOps
 import dpctl
 from numba_dppy.target import DPPYTargetContext
 from numba_dppy.dppy_array_type import DPPYArray
+<<<<<<< HEAD
 from numba_dppy.utils import address_space, convert_to_dppy_array
+=======
+from numba_dppy.utils.constants import address_space
+>>>>>>> Add an array type coversion fn
 
 
 def _print_block(block):

--- a/numba_dppy/dppy_lowerer.py
+++ b/numba_dppy/dppy_lowerer.py
@@ -56,11 +56,7 @@ from numba_dppy.driver import KernelLaunchOps
 import dpctl
 from numba_dppy.target import DPPYTargetContext
 from numba_dppy.dppy_array_type import DPPYArray
-<<<<<<< HEAD
 from numba_dppy.utils import address_space, convert_to_dppy_array
-=======
-from numba_dppy.utils.constants import address_space
->>>>>>> Add an array type coversion fn
 
 
 def _print_block(block):

--- a/numba_dppy/dppy_passes.py
+++ b/numba_dppy/dppy_passes.py
@@ -290,7 +290,7 @@ class SpirvFriendlyLowering(LoweringPass):
         targetctx = state.targetctx
 
         library = state.library
-        interp = state.func_ir  # why is it called this?!
+        interp = state.func_ir
         typemap = state.typemap
         restype = state.return_type
         calltypes = state.calltypes

--- a/numba_dppy/extended_numba_itanium_mangler.py
+++ b/numba_dppy/extended_numba_itanium_mangler.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from numba.core import itanium_mangler, types
-from numba_dppy import target
+from numba_dppy.utils import target
 
 
 def mangle_type_or_value(typ):

--- a/numba_dppy/extended_numba_itanium_mangler.py
+++ b/numba_dppy/extended_numba_itanium_mangler.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from numba.core import itanium_mangler, types
-from numba_dppy.utils import target
 
 
 def mangle_type_or_value(typ):

--- a/numba_dppy/printimpl.py
+++ b/numba_dppy/printimpl.py
@@ -19,14 +19,14 @@ import llvmlite.llvmpy.core as lc
 from numba.core import types, typing, cgutils
 from numba.core.imputils import Registry
 
-from .target import SPIR_GENERIC_ADDRSPACE
+from numba_dppy.utils.constants import address_space
 
 registry = Registry()
 lower = registry.lower
 
 
 def declare_print(lmod):
-    voidptrty = lc.Type.pointer(lc.Type.int(8), addrspace=SPIR_GENERIC_ADDRSPACE)
+    voidptrty = lc.Type.pointer(lc.Type.int(8), addrspace=address_space.SPIR_GENERIC)
     printfty = lc.Type.function(lc.Type.int(), [voidptrty], var_arg=True)
     printf = lmod.get_or_insert_function(printfty, "printf")
     return printf

--- a/numba_dppy/printimpl.py
+++ b/numba_dppy/printimpl.py
@@ -19,14 +19,14 @@ import llvmlite.llvmpy.core as lc
 from numba.core import types, typing, cgutils
 from numba.core.imputils import Registry
 
-from numba_dppy.utils.constants import address_space
+from numba_dppy.utils import address_space
 
 registry = Registry()
 lower = registry.lower
 
 
 def declare_print(lmod):
-    voidptrty = lc.Type.pointer(lc.Type.int(8), addrspace=address_space.SPIR_GENERIC)
+    voidptrty = lc.Type.pointer(lc.Type.int(8), addrspace=address_space.GENERIC)
     printfty = lc.Type.function(lc.Type.int(), [voidptrty], var_arg=True)
     printf = lmod.get_or_insert_function(printfty, "printf")
     return printf

--- a/numba_dppy/target.py
+++ b/numba_dppy/target.py
@@ -113,7 +113,6 @@ spirv_data_model_manager = _init_data_model_manager()
 
 class DPPYTargetContext(BaseContext):
     implement_powi_as_math_call = True
-    generic_addrspace = address_space.GENERIC
 
     def init(self):
         self._internal_codegen = codegen.JITSPIRVCodegen("numba_dppy.jit")
@@ -514,28 +513,3 @@ class DPPYCallConv(MinimalCallConv):
         )
         builder.store(retval, retptr)
         builder.ret_void()
-
-    # def decode_arguments(self, builder, argtypes, func):
-    #     """
-    #     Get the decoded (unpacked) Python arguments with *argtypes*
-    #     from LLVM function *func*.  A tuple of LLVM values is returned.
-    #     """
-    #     raw_args = self.get_arguments(func)
-    #     arginfo = self._get_arg_packer(argtypes)
-    #     args_list = []
-    #     # Cast all global address space pointer args generic address space
-    #     # pointers
-    #     for argnum in range(len(raw_args)):
-    #         arg = raw_args[argnum]
-    #         argtype = arginfo.argument_types[argnum]
-    #         if (
-    #             isinstance(argtype, llvmir.PointerType)
-    #             and argtype.addrspace == address_space.SPIR_GLOBAL_ADDRSPACE
-    #         ):
-    #             ptras = llvmir.PointerType(
-    #                 arg.type.pointee, addrspace=address_space.SPIR_GENERIC_ADDRSPACE
-    #             )
-    #             arg = builder.addrspacecast(arg, ptras)
-    #         args_list.append(arg)
-    #     breakpoint()
-    #     return arginfo.from_arguments(builder, tuple(args_list))

--- a/numba_dppy/target.py
+++ b/numba_dppy/target.py
@@ -61,7 +61,7 @@ class DPPYTypingContext(typing.BaseContext):
             ValueError: If the type of the Python value is not supported.
 
         """
-        if typeof(val) == types.npytypes.Array:
+        if isinstance(typeof(val), types.npytypes.Array):
             # convert npytypes.Array to DPPYArray
             return convert_to_dppy_array(typeof(val))
         else:

--- a/numba_dppy/tests/test_itanium_mangler_extension.py
+++ b/numba_dppy/tests/test_itanium_mangler_extension.py
@@ -17,13 +17,7 @@ import pytest
 import numba_dppy.extended_numba_itanium_mangler as itanium_mangler
 from numba import int32, int64, uint32, uint64, float32, float64
 from numba.core import types
-from numba_dppy.target import (
-    SPIR_PRIVATE_ADDRSPACE,
-    SPIR_GLOBAL_ADDRSPACE,
-    SPIR_CONSTANT_ADDRSPACE,
-    SPIR_LOCAL_ADDRSPACE,
-    SPIR_GENERIC_ADDRSPACE,
-)
+from numba_dppy.utils import address_space
 
 list_of_dtypes = [
     (int32, "i"),
@@ -41,11 +35,11 @@ def dtypes(request):
 
 
 list_of_addrspaces = [
-    (SPIR_PRIVATE_ADDRSPACE, "3AS0"),
-    (SPIR_GLOBAL_ADDRSPACE, "3AS1"),
-    (SPIR_CONSTANT_ADDRSPACE, "3AS2"),
-    (SPIR_LOCAL_ADDRSPACE, "3AS3"),
-    (SPIR_GENERIC_ADDRSPACE, "3AS4"),
+    (address_space.SPIR_PRIVATE, "3AS0"),
+    (address_space.SPIR_GLOBAL, "3AS1"),
+    (address_space.SPIR_CONSTANT, "3AS2"),
+    (address_space.SPIR_LOCAL, "3AS3"),
+    (address_space.SPIR_GENERIC, "3AS4"),
 ]
 
 

--- a/numba_dppy/tests/test_itanium_mangler_extension.py
+++ b/numba_dppy/tests/test_itanium_mangler_extension.py
@@ -35,11 +35,10 @@ def dtypes(request):
 
 
 list_of_addrspaces = [
-    (address_space.SPIR_PRIVATE, "3AS0"),
-    (address_space.SPIR_GLOBAL, "3AS1"),
-    (address_space.SPIR_CONSTANT, "3AS2"),
-    (address_space.SPIR_LOCAL, "3AS3"),
-    (address_space.SPIR_GENERIC, "3AS4"),
+    (address_space.PRIVATE, "3AS0"),
+    (address_space.GLOBAL, "3AS1"),
+    (address_space.LOCAL, "3AS3"),
+    (address_space.GENERIC, "3AS4"),
 ]
 
 


### PR DESCRIPTION
WIP changes to `target.py` to remove the wrapper function needed for every kernel. 