### PR TITLE
feature/upgrade_to_dpctl_0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ https://intelpython.github.io/dpnp/
 ## Dependencies
 
 * numba 0.53.* (IntelPython/numba)
-* dpctl 0.7.*
+* dpctl 0.8.*
 * dpnp 0.6.* (optional)
 * llvm-spirv (SPIRV generation from LLVM IR)
 * llvmdev (LLVM IR generation)
 * spirv-tools
 * cython (for building)
-* pytest (for testing) 
+* pytest (for testing)
 * scipy (for testing)
 
 ## dppy

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
         - setuptools
         - cython
         - numba 0.53*
-        - dpctl 0.7.*
+        - dpctl 0.8.*
         - dpnp >=0.6*,<0.7*  # [linux]
         - wheel
     run:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     run:
         - python
         - numba 0.53*
-        - dpctl 0.7.*
+        - dpctl 0.8.*
         - spirv-tools
         - llvm-spirv
         - llvmdev

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -27,14 +27,14 @@ class DpctlMinimumVersionRequiredError(Exception):
     pass
 
 
-# Check for dpctl 0.7.0 or higher on the system.
+# Check for dpctl 0.8.0 or higher in the system.
 _dpctl_found = False
 try:
     import dpctl
 
-    # Versions of dpctl lower than 0.7.0 are not compatible with current main
+    # Versions of dpctl lower than 0.8.0 are not compatible with current main
     # of numba_dppy.
-    if version.parse(dpctl.__version__) < version.parse("0.7.0"):
+    if version.parse(dpctl.__version__) < version.parse("0.8.*"):
         raise DpctlMinimumVersionRequiredError
 
     # For the Numba_dppy extension to work, we should have at least one
@@ -47,10 +47,11 @@ try:
         msg += "A non-host SYCL device is required to use numba_dppy."
         warnings.warn(msg, UserWarning)
 except DpctlMinimumVersionRequiredError:
-    msg = "numba_dppy requires dpctl 0.7.0 or higher."
+    msg = "numba_dppy is not compatible with " + dpctl.__version__ + "."
+    msg += " Install dpctl 0.8.* or higher."
     warnings.warn(msg, UserWarning)
 except:
-    msg = "Please install dpctl 0.7.0 or higher."
+    msg = "Please install dpctl 0.8.* or higher."
     warnings.warn(msg, UserWarning)
 
 # Set this config flag based on if dpctl is found or not. The config flags is

--- a/numba_dppy/numpy_usm_shared.py
+++ b/numba_dppy/numpy_usm_shared.py
@@ -44,8 +44,8 @@ from numba.core.typing.templates import (
 from numba.core.typing.arraydecl import normalize_shape
 from numba.np.arrayobj import _array_copy
 
-import dpctl.dptensor.numpy_usm_shared as nus
-from dpctl.dptensor.numpy_usm_shared import ndarray, functions_list, class_list
+import dpctl.tensor.numpy_usm_shared as nus
+from dpctl.tensor.numpy_usm_shared import ndarray, functions_list, class_list
 from . import target as dppy_target
 from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
 
@@ -284,7 +284,7 @@ def numba_register_lower_builtin():
 
     for impl, func, types in todo + todo_builtin:
         try:
-            usmarray_func = eval("dpctl.dptensor.numpy_usm_shared." + func.__name__)
+            usmarray_func = eval("dpctl.tensor.numpy_usm_shared." + func.__name__)
         except:
             dprint("failed to eval", func.__name__)
             continue
@@ -339,7 +339,7 @@ def numba_register_typing():
         dprint("todo_classes:", val, typ, type(typ))
 
         try:
-            dptype = eval("dpctl.dptensor.numpy_usm_shared." + val.__name__)
+            dptype = eval("dpctl.tensor.numpy_usm_shared." + val.__name__)
         except:
             dprint("failed to eval", val.__name__)
             continue
@@ -354,7 +354,7 @@ def numba_register_typing():
         template = typ.templates[0]
         dprint("need to re-register for usmarray", val, typ, typ.typing_key)
         try:
-            dpval = eval("dpctl.dptensor.numpy_usm_shared." + val.__name__)
+            dpval = eval("dpctl.tensor.numpy_usm_shared." + val.__name__)
         except:
             dprint("failed to eval", val.__name__)
             continue

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -18,7 +18,7 @@ from numba import njit, prange
 
 from numba.core import compiler, cpu
 
-import dpctl.dptensor.numpy_usm_shared as usmarray
+import dpctl.tensor.numpy_usm_shared as usmarray
 import numba_dppy.numpy_usm_shared as nus
 import dpctl
 

--- a/numba_dppy/tests/test_usmarray.py
+++ b/numba_dppy/tests/test_usmarray.py
@@ -16,7 +16,7 @@ import numba
 import numpy
 import unittest
 
-import dpctl.dptensor.numpy_usm_shared as usmarray
+import dpctl.tensor.numpy_usm_shared as usmarray
 
 
 @numba.njit()


### PR DESCRIPTION
Dpctl 0.8 changes the name of `dpctl.dptensor` to `dpctl.tensor`. This PR changes the module name `dptensor` everywhere in our code base. Additional changes to README, meta.yaml, and config.py.