### PR TITLE
Update blackscholes examples

### DIFF
--- a/numba_dppy/examples/blacksholes_kernel.py
+++ b/numba_dppy/examples/blacksholes_kernel.py
@@ -85,10 +85,14 @@ def main():
     griddim = int(math.ceil(float(OPT_N) / blockdim[0])), 1
 
     try:
-        gpu = dpctl.select_gpu_device()
-        with dpctl.device_context(gpu):
+        # Device can be selected using envar SYCL_DEVICE_FILTER.
+        # For example:
+        #    SYCL_DEVICE_FILTER=opencl:gpu python blacksholes_kernel.py
+        # Currently, SYCL_DEVICE_FILTER=host is not supported
+        sycl_device = dpctl.select_default_device()
+        with dpctl.device_context(sycl_device):
             print("Offloading to ...")
-            gpu.print_device_info()
+            sycl_device.print_device_info()
             time1 = time.time()
             for i in range(iterations):
                 black_scholes_dppy[blockdim, griddim](
@@ -101,7 +105,7 @@ def main():
                     VOLATILITY,
                 )
     except ValueError:
-        print("No SYCL gpu found")
+        print("No SYCL device found")
 
     print("callResult : \n", callResult)
     print("putResult : \n", putResult)

--- a/numba_dppy/examples/blacksholes_njit.py
+++ b/numba_dppy/examples/blacksholes_njit.py
@@ -70,10 +70,14 @@ def main():
     options = args.options
 
     # Run the example of a deafult GPU device
-    gpu_device = dpctl.select_gpu_device()
-    with dpctl.device_context(gpu_device):
+    # Device can be selected using envar SYCL_DEVICE_FILTER.
+    # For example:
+    #   SYCL_DEVICE_FILTER=opencl:gpu python blacksholes_njit.py
+    # Currently, SYCL_DEVICE_FILTER=host is not supported
+    sycl_device = dpctl.select_default_device()
+    with dpctl.device_context(sycl_device):
         print("Offloading to ...")
-        gpu_device.print_device_info()
+        sycl_device.print_device_info()
         run(10)
 
 


### PR DESCRIPTION
The examples are updated to use `dpctl.select_default_device()`.