### PR TITLE
Fix kernel caching.

### DIFF
--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -588,7 +588,7 @@ class JitDPPYKernel(DPPYKernelBase):
 
     def specialize(self, *args):
         argtypes = tuple([self.typingctx.resolve_argument_type(a) for a in args])
-        q = None
+        sycl_ctx = None
         kernel = None
         # we were previously using the _env_ptr of the device_env, the sycl_queue
         # should be sufficient to cache the compiled kernel for now, but we should
@@ -597,13 +597,13 @@ class JitDPPYKernel(DPPYKernelBase):
         key_definitions = argtypes
         result = self.definitions.get(key_definitions)
         if result:
-            q, kernel = result
+            sycl_ctx, kernel = result
 
-        if q == self.sycl_queue:
+        if sycl_ctx and sycl_ctx == self.sycl_queue.sycl_context:
             return kernel
         else:
             kernel = compile_kernel(
                 self.sycl_queue, self.py_func, argtypes, self.access_types
             )
-            self.definitions[key_definitions] = (self.sycl_queue, kernel)
+            self.definitions[key_definitions] = (self.sycl_queue.sycl_context, kernel)
         return kernel

--- a/numba_dppy/tests/kernel_tests/test_caching.py
+++ b/numba_dppy/tests/kernel_tests/test_caching.py
@@ -30,27 +30,62 @@ def filter_str(request):
     return request.param
 
 
-def data_parallel_sum(a, b, c):
-    i = dppy.get_global_id(0)
-    c[i] = a[i] + b[i]
+def test_caching_kernel_using_same_queue(filter_str):
+    """Test kernel caching when the same queue is used to submit a kernel
+    multiple times.
 
-
-def test_caching_kernel(filter_str):
+    Args:
+        filter_str: SYCL filter selector string
+    """
     if skip_test(filter_str):
         pytest.skip()
     global_size = 10
     N = global_size
 
+    def data_parallel_sum(a, b, c):
+        i = dppy.get_global_id(0)
+        c[i] = a[i] + b[i]
+
     a = np.array(np.random.random(N), dtype=np.float32)
     b = np.array(np.random.random(N), dtype=np.float32)
     c = np.ones_like(a)
 
-    with dpctl.device_context(filter_str) as gpu_queue:
+    with dpctl.device_context(filter_str):
         func = dppy.kernel(data_parallel_sum)
-        caching_kernel = func[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(a, b, c)
+        cached_kernel = func[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(a, b, c)
 
         for i in range(10):
-            cached_kernel = func[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(
-                a, b, c
-            )
-            assert caching_kernel == cached_kernel
+            _kernel = func[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(a, b, c)
+            assert _kernel == cached_kernel
+
+
+def test_caching_kernel_using_same_context(filter_str):
+    """Test kernel caching for the scenario where different SYCL queues that
+    share a SYCL context are used to submit a kernel.
+
+    Args:
+        filter_str: SYCL filter selector string
+    """
+    if skip_test(filter_str):
+        pytest.skip()
+    global_size = 10
+    N = global_size
+
+    def data_parallel_sum(a, b, c):
+        i = dppy.get_global_id(0)
+        c[i] = a[i] + b[i]
+
+    a = np.array(np.random.random(N), dtype=np.float32)
+    b = np.array(np.random.random(N), dtype=np.float32)
+    c = np.ones_like(a)
+
+    # Set the global queue to the default device so that the cached_kernel gets
+    # created for that device
+    dpctl.set_global_queue(filter_str)
+    func = dppy.kernel(data_parallel_sum)
+    cached_kernel = func[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(a, b, c)
+    for i in range(0, 10):
+        # Each iteration create a fresh queue that will share the same context
+        with dpctl.device_context(filter_str):
+            _kernel = func[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(a, b, c)
+            assert _kernel == cached_kernel


### PR DESCRIPTION
  - Kernel caching based on SYCL queue no longer works as dpctl does not cache queues
    globally. Instead, dpctl caches a default SYCL context for every root device.
  - Changed the kernel caching logic in compiler.py accordingly and added a test case.

Closes #407 