### PR TITLE
Remove imports from future.

### DIFF
--- a/numba_dppy/__init__.py
+++ b/numba_dppy/__init__.py
@@ -515,8 +515,6 @@ Supported NumPy Functions:
 
 """
 
-from __future__ import print_function, absolute_import, division
-
 import numba.testing
 
 from .config import dppy_present

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, absolute_import
 import copy
 from collections import namedtuple
 

--- a/numba_dppy/decorators.py
+++ b/numba_dppy/decorators.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, absolute_import, division
 from numba.core import sigutils, types
 from .compiler import (
     compile_kernel,

--- a/numba_dppy/descriptor.py
+++ b/numba_dppy/descriptor.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
 from numba.core.descriptors import TargetDescriptor
 from numba.core.options import TargetOptions
 

--- a/numba_dppy/device_init.py
+++ b/numba_dppy/device_init.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, absolute_import, division
-
 # Re export
 from .ocl.stubs import (
     get_global_id,

--- a/numba_dppy/dppy_lowerer.py
+++ b/numba_dppy/dppy_lowerer.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 import ast
 import copy
 from collections import OrderedDict

--- a/numba_dppy/dppy_passbuilder.py
+++ b/numba_dppy/dppy_passbuilder.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from numba.core.compiler_machinery import PassManager
 
 from numba.core.untyped_passes import (

--- a/numba_dppy/dppy_passes.py
+++ b/numba_dppy/dppy_passes.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
 from contextlib import contextmanager
 import warnings
 

--- a/numba_dppy/dufunc_inliner.py
+++ b/numba_dppy/dufunc_inliner.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from numba.core import ir
 from numba.core.ir_utils import dead_code_elimination, simplify_CFG
 

--- a/numba_dppy/examples/matmul.py
+++ b/numba_dppy/examples/matmul.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from timeit import default_timer as time
 import numpy as np
 import numba_dppy as dppy

--- a/numba_dppy/ocl/mathdecl.py
+++ b/numba_dppy/ocl/mathdecl.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, absolute_import, division
 import math
 from numba.core import types, utils
 from numba.core.typing.templates import (

--- a/numba_dppy/ocl/mathimpl.py
+++ b/numba_dppy/ocl/mathimpl.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, absolute_import, division
 import math
 import numpy
 import warnings

--- a/numba_dppy/ocl/ocldecl.py
+++ b/numba_dppy/ocl/ocldecl.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
 from numba import types
 from numba.core.typing.npydecl import register_number_classes, parse_dtype, parse_shape
 from numba.core.typing.templates import (

--- a/numba_dppy/ocl/oclimpl.py
+++ b/numba_dppy/ocl/oclimpl.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import operator
 from functools import reduce
 

--- a/numba_dppy/ocl/stubs.py
+++ b/numba_dppy/ocl/stubs.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, absolute_import
 from numba.core import types, ir, typing
 
 from numba_dppy.target import SPIR_LOCAL_ADDRSPACE

--- a/numba_dppy/printimpl.py
+++ b/numba_dppy/printimpl.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, absolute_import, division
-
 from functools import singledispatch
 
 import llvmlite.llvmpy.core as lc

--- a/numba_dppy/target.py
+++ b/numba_dppy/target.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, absolute_import
-
 import re
 import numpy as np
 


### PR DESCRIPTION
  Numba now only supports Python 3, we do not need the imports  from future any more in our sources as well.