### PR TITLE
Refactored constants from target to utils.

### DIFF
--- a/numba_dppy/ocl/ocldecl.py
+++ b/numba_dppy/ocl/ocldecl.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from numba import types
-from numba.core.typing.npydecl import register_number_classes, parse_dtype, parse_shape
+from numba.core.typing.npydecl import parse_dtype, parse_shape
 from numba.core.typing.templates import (
     AttributeTemplate,
     ConcreteTemplate,
@@ -22,9 +22,9 @@ from numba.core.typing.templates import (
     signature,
     Registry,
 )
-import numba_dppy, numba_dppy as dppy
-from numba_dppy import target
+import numba_dppy as dppy
 from numba_dppy.dppy_array_type import DPPYArray
+from numba_dppy.utils import address_space
 
 registry = Registry()
 intrinsic = registry.register
@@ -168,7 +168,7 @@ class OCL_local_array(CallableTemplate):
                     dtype=nb_dtype,
                     ndim=ndim,
                     layout="C",
-                    addrspace=target.SPIR_LOCAL_ADDRSPACE,
+                    addrspace=address_space.LOCAL,
                 )
 
         return typer

--- a/numba_dppy/ocl/oclimpl.py
+++ b/numba_dppy/ocl/oclimpl.py
@@ -29,6 +29,7 @@ from numba_dppy import target
 from numba_dppy.codegen import SPIR_DATA_LAYOUT
 from numba_dppy.dppy_array_type import DPPYArray
 from numba_dppy.ocl.atomics import atomic_helper
+from numba_dppy.utils import address_space
 
 from . import stubs
 
@@ -206,14 +207,14 @@ def insert_and_call_atomic_fn(
     else:
         raise TypeError("Atomic operation is not supported for type %s" % (dtype.name))
 
-    if addrspace == target.SPIR_LOCAL_ADDRSPACE:
+    if addrspace == address_space.LOCAL:
         name = name + "_local"
     else:
         name = name + "_global"
 
     assert ll_p != None
     assert name != ""
-    ll_p.addrspace = target.SPIR_GENERIC_ADDRSPACE
+    ll_p.addrspace = address_space.GENERIC
 
     mod = builder.module
     if sig.return_type == types.void:
@@ -227,7 +228,7 @@ def insert_and_call_atomic_fn(
     fn = mod.get_or_insert_function(fnty, name)
     fn.calling_convention = target.CC_SPIR_FUNC
 
-    generic_ptr = context.addrspacecast(builder, ptr, target.SPIR_GENERIC_ADDRSPACE)
+    generic_ptr = context.addrspacecast(builder, ptr, address_space.GENERIC)
 
     return builder.call(fn, [generic_ptr, val])
 
@@ -271,10 +272,10 @@ def native_atomic_add(context, builder, sig, args):
 
     ptr_type = context.get_value_type(dtype).as_pointer()
     if not hasattr(aryty, "addrspace"):
-        ptr_type.addrspace = target.SPIR_GLOBAL_ADDRSPACE
-        ptr = context.addrspacecast(builder, ptr, target.SPIR_GLOBAL_ADDRSPACE)
+        ptr_type.addrspace = address_space.GLOBAL
+        ptr = context.addrspacecast(builder, ptr, address_space.GLOBAL)
     else:
-        ptr_type.addrspace = target.SPIR_LOCAL_ADDRSPACE
+        ptr_type.addrspace = address_space.LOCAL
     retty = context.get_value_type(sig.return_type)
     spirv_fn_arg_types = [
         ptr_type,
@@ -408,10 +409,7 @@ def atomic_add(context, builder, sig, args, name):
         lary = context.make_array(aryty)(context, builder, ary)
         ptr = cgutils.get_item_pointer(context, builder, aryty, lary, indices)
 
-        if (
-            isinstance(aryty, DPPYArray)
-            and aryty.addrspace == target.SPIR_LOCAL_ADDRSPACE
-        ):
+        if isinstance(aryty, DPPYArray) and aryty.addrspace == address_space.LOCAL:
             return insert_and_call_atomic_fn(
                 context,
                 builder,
@@ -420,7 +418,7 @@ def atomic_add(context, builder, sig, args, name):
                 dtype,
                 ptr,
                 val,
-                target.SPIR_LOCAL_ADDRSPACE,
+                address_space.LOCAL,
             )
         else:
             return insert_and_call_atomic_fn(
@@ -431,7 +429,7 @@ def atomic_add(context, builder, sig, args, name):
                 dtype,
                 ptr,
                 val,
-                target.SPIR_GLOBAL_ADDRSPACE,
+                address_space.GLOBAL,
             )
     else:
         raise ImportError("Atomic support is not present, can not perform atomic_add")
@@ -447,7 +445,7 @@ def dppy_local_array_integer(context, builder, sig, args):
         shape=(length,),
         dtype=dtype,
         symbol_name="_dppy_lmem",
-        addrspace=target.SPIR_LOCAL_ADDRSPACE,
+        addrspace=address_space.LOCAL,
     )
 
 
@@ -462,7 +460,7 @@ def dppy_local_array_tuple(context, builder, sig, args):
         shape=shape,
         dtype=dtype,
         symbol_name="_dppy_lmem",
-        addrspace=target.SPIR_LOCAL_ADDRSPACE,
+        addrspace=address_space.LOCAL,
     )
 
 
@@ -475,7 +473,7 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace):
     lldtype = context.get_data_type(dtype)
     laryty = Type.array(lldtype, elemcount)
 
-    if addrspace == target.SPIR_LOCAL_ADDRSPACE:
+    if addrspace == address_space.LOCAL:
         lmod = builder.module
 
         # Create global variable in the requested address-space
@@ -508,7 +506,7 @@ def _make_array(
     dtype,
     shape,
     layout="C",
-    addrspace=target.SPIR_GENERIC_ADDRSPACE,
+    addrspace=address_space.GENERIC,
 ):
     ndim = len(shape)
     # Create array object

--- a/numba_dppy/ocl/stubs.py
+++ b/numba_dppy/ocl/stubs.py
@@ -14,7 +14,6 @@
 
 from numba.core import types, ir, typing
 
-from numba_dppy.target import SPIR_LOCAL_ADDRSPACE
 import numpy as np
 import numba
 from numba.np import numpy_support

--- a/numba_dppy/utils/__init__.py
+++ b/numba_dppy/utils/__init__.py
@@ -25,11 +25,17 @@ from numba_dppy.utils.llvm_codegen_helpers import (
     get_one,
 )
 
+from numba_dppy.utils.type_conversion_fns import convert_to_dppy_array
+from numba_dppy.utils.constants import address_space, calling_conv
+
 __all__ = [
-    LLVMTypes,
-    get_llvm_type,
-    get_llvm_ptr_type,
-    create_null_ptr,
-    get_zero,
-    get_one,
+    "LLVMTypes",
+    "get_llvm_type",
+    "get_llvm_ptr_type",
+    "create_null_ptr",
+    "get_zero",
+    "get_one",
+    "convert_to_dppy_array",
+    "address_space",
+    "calling_conv",
 ]

--- a/numba_dppy/utils/constants.py
+++ b/numba_dppy/utils/constants.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Defines constants that are used in other modules.
+
+"""
+from enum import Enum
+
+__all__ = ["address_space", "calling_conv"]
+
+
+class address_space:
+    """The address space values supported by numba-dppy.
+
+    ==================   ============
+    Address space        Value
+    ==================   ============
+    PRIVATE              0
+    GLOBAL               1
+    CONSTANT             2
+    LOCAL                3
+    GENERIC              4
+    ==================   ============
+
+    """
+
+    PRIVATE = 0
+    GLOBAL = 1
+    CONSTANT = 2
+    LOCAL = 3
+    GENERIC = 4
+
+
+class calling_conv:
+    CC_SPIR_KERNEL = "spir_kernel"
+    CC_SPIR_FUNC = "spir_func"

--- a/numba_dppy/utils/type_conversion_fns.py
+++ b/numba_dppy/utils/type_conversion_fns.py
@@ -1,0 +1,65 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Provides helper functions to convert from numba types to numba_dppy types.
+
+Currently the module supports the following converter functions:
+    - convert_to_dppy_array: types.npytypes.Array to
+                             numba_dppy.dppy_array_type.DPPYArray.
+
+"""
+from numba.core import types
+from numba_dppy import dppy_array_type
+from .constants import address_space
+
+__all__ = ["convert_to_dppy_array"]
+
+
+def convert_to_dppy_array(arrtype, addrspace=address_space.GLOBAL):
+    """Convert   Numba's Array type to numba_dppy's DPPYArray type.
+
+    Numba's ``Array`` type does not have a notion of address space for the data
+    pointer. For this reason, numba_dppy defines its own array type (DPPYArray).
+    The DPPYArray type is similar to Numba's Array, but the data pointer has an
+    address space associated with it. The converter function converts the Numba
+    Array type to DPPYArray type with address space of pointer members typed to
+    the specified address space.
+
+    Args:
+        arrtype (numba.types): A numba data type that should be
+            ``numba.types.Array``.
+        specified: Defaults to ``numba_dppy.utils.address_space.GLOBAL``.
+            The SPIR-V address space to which the data pointer of the array
+            belongs.
+
+    Returns: The numba_dppy data type corresponding to the input numba type.
+
+    Raises:
+        NotImplementedError: If the input numba type is not
+                             ``numba.types.Array``
+
+    """
+    if isinstance(arrtype, types.npytypes.Array):
+        return dppy_array_type.DPPYArray(
+            arrtype.dtype,
+            arrtype.ndim,
+            arrtype.layout,
+            arrtype.py_type,
+            not arrtype.mutable,
+            arrtype.name,
+            arrtype.aligned,
+            addrspace=addrspace,
+        )
+    else:
+        raise NotImplementedError


### PR DESCRIPTION
  - Moved the constant address space values to the utils module.
  - Changed the name of all address spaces from "SPIR_*_ADDRSPACE"
    to "GLOBAL", "LOCAL", etc. The change was done to make the
    names in line with SYCL address spaces names rather than
    SPIR-V address spaces.
  - Added a type conversion function to convert npytypes.Array to
    DPPYArray. The utility function is currently used only in
    dppy_lowerer.py, but will be used in other places in future.
  - Other cleanups such as removed commented out code and unused
    imports.

This PR has some preliminary changes that will be used in the later PR to remove the kernel wrapper.