### PR TITLE
Update debugging documentation main case

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ There are two ways to program SYCL devices using Numba-dppy:
         import dpctl
 
         @dppy.kernel
-            def sum(a, b, c):
+        def sum(a, b, c):
             i = dppy.get_global_id(0)
             c[i] = a[i] + b[i]
 

--- a/docs/user_guides/debugging/index.rst
+++ b/docs/user_guides/debugging/index.rst
@@ -72,6 +72,16 @@ Running GDB and creating breakpoint in kernel:
     (gdb) next
     8          c[i] = a[i] + b[i]
 
+If breakpoint does not work and you see in output
+
+.. code-block:: bash
+
+    ...
+    intelgt: gdbserver-gt failed to start.  Check if igfxdcd is installed, or use
+    env variable INTELGT_AUTO_ATTACH_DISABLE=1 to disable auto-attach.
+    ...
+
+then see :ref:`debugging-machine-dcd-driver`.
 
 .. _debugging-features-and-limitations:
 

--- a/docs/user_guides/debugging/set_up_machine.rst
+++ b/docs/user_guides/debugging/set_up_machine.rst
@@ -61,6 +61,8 @@ See also:
   - `OpenCL ICD Loader <https://github.com/KhronosGroup/OpenCL-ICD-Loader>`_
 
 
+.. _debugging-machine-dcd-driver:
+
 DCD driver
 ----------
 


### PR DESCRIPTION
Main page should provide tutorial with example where most useful features should be used.
Tutorial should contain end to end example of GDB usage.