### PR TITLE
Tests improvements for debuginfo

### DIFF
--- a/numba_dppy/tests/test_debuginfo.py
+++ b/numba_dppy/tests/test_debuginfo.py
@@ -57,9 +57,6 @@ def test_debug_flag_generates_ir_with_debuginfo(offload_device, debug_option):
     if skip_test(offload_device):
         pytest.skip()
 
-    if offload_device in "level_zero:gpu:0":
-        pytest.xfail("Failing compilation: SyclProgramCompilationError")
-
     @dppy.kernel
     def foo(x):
         return x

--- a/numba_dppy/tests/test_debuginfo.py
+++ b/numba_dppy/tests/test_debuginfo.py
@@ -125,10 +125,7 @@ def test_debug_kernel_local_vars_in_ir():
         local_d = 9 * 99 + 5
         arr[index] = local_d + 100
 
-    ir_tags = [
-        '!DILocalVariable(name: "index"',
-        '!DILocalVariable(name: "local_d"'
-    ]
+    ir_tags = ['!DILocalVariable(name: "index"', '!DILocalVariable(name: "local_d"']
 
     sycl_queue = dpctl.get_current_queue()
     sig = (types.float32[:],)

--- a/numba_dppy/tests/test_debuginfo.py
+++ b/numba_dppy/tests/test_debuginfo.py
@@ -49,26 +49,26 @@ def make_check(ir, val_to_search):
     return got
 
 
-def test_debug_flag_generates_ir_with_debuginfo(offload_device, debug_option):
+def test_debug_flag_generates_ir_with_debuginfo(debug_option):
     """
     Check debug info is emitting to IR if debug parameter is set to True
     """
-
-    if skip_test(offload_device):
-        pytest.skip()
 
     @dppy.kernel
     def foo(x):
         return x
 
-    with dpctl.device_context(offload_device) as sycl_queue:
-        sig = (types.int32,)
-        kernel_ir = get_kernel_ir(sycl_queue, foo, sig, debug=debug_option)
+    sycl_queue = dpctl.get_current_queue()
+    sig = (types.int32,)
 
-        expect = debug_option
-        got = make_check(kernel_ir, r"!dbg")
+    kernel_ir = get_kernel_ir(sycl_queue, foo, sig, debug=debug_option)
 
-        assert expect == got
+    tag = "!dbg"
+
+    if debug_option:
+        assert tag in kernel_ir
+    else:
+        assert tag not in kernel_ir
 
 
 def test_debug_info_locals_vars_on_no_opt(offload_device):

--- a/numba_dppy/tests/test_dpnp_functions.py
+++ b/numba_dppy/tests/test_dpnp_functions.py
@@ -29,7 +29,7 @@ class Testdpnp_functions(unittest.TestCase):
 
     a = np.array(np.random.random(N), dtype=np.float32)
     b = np.array(np.random.random(N), dtype=np.float32)
-    tys = [np.int32, np.uint32, np.int64, np.uint64, np.float, np.double]
+    tys = [np.int32, np.uint32, np.int64, np.uint64, np.float32, np.double]
 
     def test_dpnp_interacting_with_parfor(self):
         def f(a, b):


### PR DESCRIPTION
Proposed improvements:
1. use `assert tag in ir` - it shows good explanation, but requires `tag` to be simple string
2. if RE not necessary then use simple strings
3. get `sycl_queue` from `dpctl.get_current_queue()` - device context is not necessary
4. test on default device - IR does not depend on device - 1 test instead of 3 tests