### PR TITLE
Raise error when users are trying to return from kernel

### DIFF
--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -131,6 +131,12 @@ def compile_with_dppy(pyfunc, return_type, args, debug=None):
         )
     else:
         assert 0
+
+    retty = cres.signature.return_type
+    if retty is not None and retty != types.void:
+        msg = "DPPY kernel must have void return type but got {retty}"
+        raise TypeError(msg.format(retty=retty))
+
     # Linking depending libraries
     library = cres.library
     library.finalize()

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -34,6 +34,7 @@ from numba_dppy.dppy_parfor_diagnostics import ExtendedParforDiagnostics
 from numba_dppy import config
 from numba_dppy.driver import USMNdArrayType
 from numba_dppy.dppy_array_type import DPPYArray
+from numba_dppy.utils import assert_no_return
 
 
 _NUMBA_DPPY_READ_ONLY = "read_only"
@@ -89,7 +90,7 @@ class DPPYCompiler(CompilerBase):
         return pms
 
 
-def compile_with_dppy(pyfunc, return_type, args, debug=None):
+def compile_with_dppy(pyfunc, return_type, args, is_kernel, debug=None):
     # First compilation will trigger the initialization of the OpenCL backend.
     from .descriptor import dppy_target
 
@@ -132,10 +133,8 @@ def compile_with_dppy(pyfunc, return_type, args, debug=None):
     else:
         assert 0
 
-    retty = cres.signature.return_type
-    if retty is not None and retty != types.void:
-        msg = "DPPY kernel must have void return type but got {retty}"
-        raise TypeError(msg.format(retty=retty))
+    if is_kernel:
+        assert_no_return(cres.signature.return_type)
 
     # Linking depending libraries
     library = cres.library
@@ -160,7 +159,7 @@ def compile_kernel(sycl_queue, pyfunc, args, access_types, debug=None):
         # We expect the sycl_queue to be provided when this function is called
         raise ValueError("SYCL queue is required for compiling a kernel")
 
-    cres = compile_with_dppy(pyfunc, None, args, debug=debug)
+    cres = compile_with_dppy(pyfunc, None, args, True, debug=debug)
     func = cres.library.get_function(cres.fndesc.llvm_func_name)
     kernel = cres.target_context.prepare_ocl_kernel(func, cres.signature.args)
 
@@ -194,7 +193,7 @@ def compile_kernel_parfor(sycl_queue, func_ir, args, args_with_addrspaces, debug
             if isinstance(a, types.npytypes.Array):
                 print("addrspace:", a.addrspace)
 
-    cres = compile_with_dppy(func_ir, None, args_with_addrspaces, debug=debug)
+    cres = compile_with_dppy(func_ir, None, args_with_addrspaces, True, debug=debug)
     func = cres.library.get_function(cres.fndesc.llvm_func_name)
 
     if config.DEBUG:
@@ -215,7 +214,7 @@ def compile_kernel_parfor(sycl_queue, func_ir, args, args_with_addrspaces, debug
 
 
 def compile_dppy_func(pyfunc, return_type, args, debug=None):
-    cres = compile_with_dppy(pyfunc, return_type, args, debug=debug)
+    cres = compile_with_dppy(pyfunc, return_type, args, False, debug=debug)
     func = cres.library.get_function(cres.fndesc.llvm_func_name)
     cres.target_context.mark_ocl_device(func)
     devfn = DPPYFunction(cres)
@@ -265,7 +264,7 @@ class DPPYFunctionTemplate(object):
         this object.
         """
         if args not in self._compileinfos:
-            cres = compile_with_dppy(self.py_func, None, args, debug=self.debug)
+            cres = compile_with_dppy(self.py_func, None, args, False, debug=self.debug)
             func = cres.library.get_function(cres.fndesc.llvm_func_name)
             cres.target_context.mark_ocl_device(func)
             first_definition = not self._compileinfos

--- a/numba_dppy/decorators.py
+++ b/numba_dppy/decorators.py
@@ -60,6 +60,7 @@ def _kernel_jit(signature, debug, access_types):
         ]
     )
 
+    # Raises TypeError when users return anything inside @dppy.kernel.
     assert_no_return(rettype)
 
     def _wrapped(pyfunc):

--- a/numba_dppy/decorators.py
+++ b/numba_dppy/decorators.py
@@ -15,7 +15,7 @@
 import dpctl
 from numba.core import sigutils, types
 
-from numba_dppy.utils import npytypes_array_to_dppy_array
+from numba_dppy.utils import npytypes_array_to_dppy_array, assert_no_return
 
 from .compiler import (
     compile_kernel,
@@ -50,7 +50,7 @@ def autojit(debug=None, access_types=None):
 
 
 def _kernel_jit(signature, debug, access_types):
-    argtypes, restype = sigutils.normalize_signature(signature)
+    argtypes, rettype = sigutils.normalize_signature(signature)
     argtypes = tuple(
         [
             npytypes_array_to_dppy_array(ty)
@@ -60,9 +60,7 @@ def _kernel_jit(signature, debug, access_types):
         ]
     )
 
-    if restype is not None and restype != types.void:
-        msg = "DPPY kernel must have void return type but got {restype}"
-        raise TypeError(msg.format(restype=restype))
+    assert_no_return(rettype)
 
     def _wrapped(pyfunc):
         current_queue = dpctl.get_current_queue()

--- a/numba_dppy/tests/kernel_tests/test_return_type.py
+++ b/numba_dppy/tests/kernel_tests/test_return_type.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import numpy as np
-import numba_dppy as dppy
 import pytest
 import dpctl
 from numba_dppy.tests._helper import skip_test
+import numba_dppy as dppy
 
 
 def f(a):
@@ -40,7 +40,7 @@ def test_return(offload_device, sig):
 
     a = np.array(np.random.random(122), np.int32)
 
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         kernel = dppy.kernel(sig)(f)
 
         with dpctl.device_context(offload_device):

--- a/numba_dppy/tests/kernel_tests/test_return_type.py
+++ b/numba_dppy/tests/kernel_tests/test_return_type.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import numba_dppy as dppy
+import pytest
+import dpctl
+from numba_dppy.tests._helper import skip_test
+
+
+def f(a):
+    return a
+
+
+list_of_sig = [
+    None,
+    ("int32[::1](int32[::1])"),
+]
+
+
+@pytest.fixture(params=list_of_sig)
+def sig(request):
+    return request.param
+
+
+def test_return(offload_device, sig):
+    if skip_test(offload_device):
+        pytest.skip()
+
+    a = np.array(np.random.random(122), np.int32)
+
+    with pytest.raises(Exception):
+        kernel = dppy.kernel(sig)(f)
+
+        with dpctl.device_context(offload_device):
+            kernel[a.size, dppy.DEFAULT_LOCAL_SIZE](a)

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_manipulation.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_manipulation.py
@@ -21,7 +21,7 @@ import numpy as np
 from numba import njit
 import numba_dppy
 import pytest
-from numba_dppy.testing import dpnp_debug
+from numba_dppy.tests._helper import dpnp_debug
 from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 

--- a/numba_dppy/tests/test_debuginfo.py
+++ b/numba_dppy/tests/test_debuginfo.py
@@ -55,7 +55,7 @@ def test_debug_flag_generates_ir_with_debuginfo(debug_option):
 
     @dppy.kernel
     def foo(x):
-        return x
+        x = 1
 
     sycl_queue = dpctl.get_current_queue()
     sig = (types.int32,)

--- a/numba_dppy/utils/__init__.py
+++ b/numba_dppy/utils/__init__.py
@@ -27,6 +27,7 @@ from numba_dppy.utils.llvm_codegen_helpers import (
 
 from numba_dppy.utils.type_conversion_fns import npytypes_array_to_dppy_array
 from numba_dppy.utils.constants import address_space, calling_conv
+from numba_dppy.utils.misc import assert_no_return
 
 __all__ = [
     "LLVMTypes",
@@ -38,4 +39,5 @@ __all__ = [
     "npytypes_array_to_dppy_array",
     "address_space",
     "calling_conv",
+    "assert_no_return",
 ]

--- a/numba_dppy/utils/misc.py
+++ b/numba_dppy/utils/misc.py
@@ -17,9 +17,17 @@ from numba.core import types
 
 def assert_no_return(rettype):
     """
-    Make sure the type of return is void/None. @dppy.kernel does not
-    allow users to return any value and this function raises TypeError
-    when users do return something.
+    Make sure the type of return is void/None.
+
+    @dppy.kernel does not allow users to return any value and this
+    function raises TypeError when users do return something.
+
+    Args:
+        rettype: Numba type representing the return value.
+
+    Raises:
+        TypeError: Only None and types.void is allowed. In case
+            of any other type TypeError is raised.
     """
     if rettype is not None and rettype != types.void:
         msg = "DPPY kernel must have void return type but got {rettype}"

--- a/numba_dppy/utils/misc.py
+++ b/numba_dppy/utils/misc.py
@@ -1,0 +1,26 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from numba.core import types
+
+
+def assert_no_return(rettype):
+    """
+    Make sure the type of return is void/None. @dppy.kernel does not
+    allow users to return any value and this function raises TypeError
+    when users do return something.
+    """
+    if rettype is not None and rettype != types.void:
+        msg = "DPPY kernel must have void return type but got {rettype}"
+        raise TypeError(msg.format(rettype=rettype))


### PR DESCRIPTION
`@dppy.kernel` does not allow users to return anything. This PR adds checks to make sure this behavior is enforced and an useful error message is generated when users are trying to return from `dppy.kernel`