### PR TITLE
Remove `llvmdev` from runtime dependecies

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
         - dpctl 0.8.*
         - spirv-tools
         - llvm-spirv
-        - llvmdev
+        - packaging
         - dpnp >=0.6*,<0.7*  # [linux]
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
         - dpctl 0.8.*
         - spirv-tools
         - llvm-spirv
-        - packaging
         - dpnp >=0.6*,<0.7*  # [linux]
         - packaging
 


### PR DESCRIPTION
This PR updates the runtime dependencies specified in the conda recipe.

1. Remove `llvmdev` as we do not use `opt` to generate LLVM bitcode.
2. Introduce `packaging` as it is being used in  `numba_dppy/config.py`.

@PokhodenkoSA Do we need to use packaging [here](https://github.com/IntelPython/numba-dppy/blob/main/numba_dppy/config.py#L17) or can it be accomplished somehow else?