### PR TITLE
Use dpcpp compiler package for Linux

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 
 
-if [ ! -z "${ONEAPI_ROOT}" ]; then
-    source ${ONEAPI_ROOT}/compiler/latest/env/vars.sh
-else
-    echo "DPCPP is needed to build OpenCL kernel. Abort!"
-fi
-
 ${PYTHON} setup.py install --single-version-externally-managed --record=record.txt
 
 # Build wheel package

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,12 +8,13 @@ source:
 build:
     number: {{ GIT_DESCRIBE_NUMBER }}
     script_env:
-        - ONEAPI_ROOT
+        - ONEAPI_ROOT  # [not linux]
         - WHEELS_OUTPUT_FOLDER
 
 requirements:
     build:
         - {{ compiler('cxx') }}
+        - {{ compiler('dpcpp') }}  # [linux]
     host:
         - python
         - setuptools

--- a/setup.py
+++ b/setup.py
@@ -102,15 +102,13 @@ def _get_cmdclass():
 
 
 def spirv_compile():
-    ONEAPI_ROOT = os.environ.get("ONEAPI_ROOT")
-    if not os.path.isdir(ONEAPI_ROOT):
-        raise ValueError(f"ONEAPI_ROOT is not a directory: {ONEAPI_ROOT}")
-
     if IS_LIN:
-        compiler = "compiler/latest/linux/bin/clang"
-        compiler = os.path.join(ONEAPI_ROOT, compiler)
-        compiler = shlex.quote(compiler)
+        compiler = "clang"
     if IS_WIN:
+        ONEAPI_ROOT = os.environ.get("ONEAPI_ROOT")
+        if not os.path.isdir(ONEAPI_ROOT):
+            raise ValueError(f"ONEAPI_ROOT is not a directory: {ONEAPI_ROOT}")
+
         compiler = "compiler\\latest\\windows\\bin\\clang.exe"
         compiler = os.path.join(ONEAPI_ROOT, compiler)
 


### PR DESCRIPTION
Now dpcpp_linux-64 compiler is available on `-c intel`. It is not necessary to install oneAPI.
This PR uses dpcpp compiler package instead of using oneAPI.
Only for Linux.