### PR TITLE
Enable dpctl.tensor.usm_ndarray for @dppy.kernel

### DIFF
--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -573,7 +573,15 @@ class DPPYKernel(DPPYKernelBase):
         device_arrs.append(None)
 
         if isinstance(ty, USMNdArrayType):
-            raise NotImplementedError(ty, USMNdArrayType)
+            self._unpack_device_array_argument(
+                val.size,
+                val.dtype.itemsize,
+                val.usm_data,
+                val.shape,
+                val.strides,
+                val.ndim,
+                kernelargs,
+            )
         elif isinstance(ty, types.Array):
             packed_val = val
             usm_mem = has_usm_memory(val)

--- a/numba_dppy/driver/usm_ndarray_type.py
+++ b/numba_dppy/driver/usm_ndarray_type.py
@@ -17,6 +17,7 @@ from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
 import numba_dppy.target as dppy_target
 from dpctl.tensor import usm_ndarray
 from numba.np import numpy_support
+from numba_dppy.utils import address_space
 
 
 class USMNdArrayType(DPPYArray):
@@ -71,4 +72,11 @@ def typeof_usm_ndarray(val, c):
         raise ValueError("Unsupported array dtype: %s" % (val.dtype,))
     layout = "C"
     readonly = False
-    return USMNdArrayType(dtype, val.ndim, layout, val.usm_type, readonly=readonly)
+    return USMNdArrayType(
+        dtype,
+        val.ndim,
+        layout,
+        val.usm_type,
+        readonly=readonly,
+        addrspace=address_space.GLOBAL,
+    )

--- a/numba_dppy/target.py
+++ b/numba_dppy/target.py
@@ -69,7 +69,7 @@ class DPPYTypingContext(typing.BaseContext):
             ValueError: If the type of the Python value is not supported.
 
         """
-        if isinstance(typeof(val), types.npytypes.Array):
+        if type(typeof(val)) is types.npytypes.Array:
             # Convert npytypes.Array to DPPYArray
             return npytypes_array_to_dppy_array(typeof(val))
         else:

--- a/numba_dppy/tests/integration/test_usm_ndarray_interop.py
+++ b/numba_dppy/tests/integration/test_usm_ndarray_interop.py
@@ -66,14 +66,28 @@ def test_consuming_usm_ndarray(offload_device, dtype, usm_type):
     b = np.array(np.random.random(N), dtype=dtype)
     c = np.ones_like(a)
 
-    with dpctl.device_context(offload_device):
-        da = dpt.usm_ndarray(a.shape, dtype=a.dtype, buffer=usm_type)
+    with dpctl.device_context(offload_device) as gpu_queue:
+        da = dpt.usm_ndarray(
+            a.shape,
+            dtype=a.dtype,
+            buffer=usm_type,
+            buffer_ctor_kwargs={"queue": gpu_queue},
+        )
         da.usm_data.copy_from_host(a.reshape((-1)).view("|u1"))
 
-        db = dpt.usm_ndarray(b.shape, dtype=b.dtype, buffer=usm_type)
+        db = dpt.usm_ndarray(
+            b.shape,
+            dtype=b.dtype,
+            buffer=usm_type,
+            buffer_ctor_kwargs={"queue": gpu_queue},
+        )
         db.usm_data.copy_from_host(b.reshape((-1)).view("|u1"))
 
-        dc = dpt.usm_ndarray(c.shape, dtype=c.dtype, buffer=usm_type)
+        dc = dpt.usm_ndarray(
+            c.shape,
+            dtype=c.dtype,
+            buffer=usm_type,
+            buffer_ctor_kwargs={"queue": gpu_queue},
+        )
 
-        with pytest.raises(NotImplementedError):
-            data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](da, db, dc)
+        data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](da, db, dc)


### PR DESCRIPTION
This PR will enable use of `dpctl.tensor.usm_ndarray` in Numba-dppy for functions decorated with `@dppy.kernel`.