### PR TITLE
Update go version

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
+      with:
+          go-version: '1.16'
     - name: Install addlicense
       run: |
         export PATH=${PATH}:`go env GOPATH`/bin


### PR DESCRIPTION
The latest update in go version is causing license step in CI to fail. This is an attempt to setup a version of go that will not fail to install license  using github action.