### PR TITLE
Update Numba version to release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ def spirv_compile():
 packages = find_packages(include=["numba_dppy", "numba_dppy.*"])
 build_requires = ["cython"]
 install_requires = [
-    "numba >={},<{}".format("0.54.0rc", "0.55"),
+    "numba >={},<{}".format("0.54.0", "0.55"),
     "dpctl",
     "packaging",
 ]


### PR DESCRIPTION
This PR update Numba version from `0.54.0rc` to `0.54.0` in `setup.py`.