### PR TITLE
Runtime dependency `llvm-spirv 11.*`

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -82,7 +82,7 @@ jobs:
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
     env:
-      # conda-forge: llvm-spirv 11
+      # conda-forge: llvm-spirv 11 not on intel channel yet
       CHANNELS: ${{ matrix.integration_channels }} -c intel -c defaults -c dppy/label/dev -c numba/label/dev -c conda-forge --override-channels
 
     steps:

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -82,7 +82,8 @@ jobs:
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
     env:
-      CHANNELS: ${{ matrix.integration_channels }} -c intel -c defaults -c dppy/label/dev -c numba/label/dev --override-channels
+      # conda-forge: llvm-spirv 11
+      CHANNELS: ${{ matrix.integration_channels }} -c intel -c defaults -c dppy/label/dev -c numba/label/dev -c conda-forge --override-channels
 
     steps:
       - name: Download artifact

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ https://intelpython.github.io/dpnp/
 * numba 0.54.*
 * dpctl 0.9.*
 * dpnp 0.6.* (optional)
-* llvm-spirv (SPIRV generation from LLVM IR)
-* llvmdev (LLVM IR generation)
+* llvm-spirv 11.* (SPIRV generation from LLVM IR)
 * spirv-tools
 * packaging
 * cython (for building)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
         - numba 0.54*
         - dpctl >=0.9*
         - spirv-tools
-        - llvm-spirv
+        - llvm-spirv 11.*
         - dpnp >=0.7* # [linux]
         - packaging
 


### PR DESCRIPTION
Conda recipe should restrict installation only `llvm-spirv 11`:
numba-dppy -> Numba 0.54 -> llvmlite 0.37.0 -> LLVM11
numba-dppy -> llvm-spirv 11 -> LLVM 11

Also:
- [x] Update README: remove llvmdev dependency
- [x] Update public CI: Use conda-forge channel for llvm-spirv 11.