### PR TITLE
Update conda recipe dependency `dpnp 0.7*`

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.54*
         - dpctl >=0.10*
-        - dpnp >=0.7*  # [linux]
+        - dpnp 0.7*  # [linux]
         - wheel
     run:
         - python
@@ -28,7 +28,7 @@ requirements:
         - dpctl >=0.10*
         - spirv-tools
         - llvm-spirv 11.*
-        - dpnp >=0.7* # [linux]
+        - dpnp 0.7* # [linux]
         - packaging
 
 test:


### PR DESCRIPTION
I did not find a way to build with particular package. So I have to update the recipe.
It seems that dpnp 0.8.0dev0=_9 can not be used for building numba-dppy.