### PR TITLE
Improve build and infra scripts

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+# E501 line too long
+ignore = E501

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,16 @@
 [flake8]
 # E501 line too long
-ignore = E501
+# E722 do not use bare 'except'
+# F401 imported but unused
+# W503 line break before binary operator
+ignore = E501,E722,F401,W503
+per-file-ignores =
+    # redefinition of unused 'dpnp_random_impl'
+    dpnp_randomimpl.py: F811
+    # module level import not at top of file
+    device_init.py: E402
+exclude =
+    .git,
+    __pycache__,
+    _version.py,
+    numpy_usm_shared.py,

--- a/.flake8
+++ b/.flake8
@@ -16,3 +16,4 @@ exclude =
     __pycache__,
     _version.py,
     numpy_usm_shared.py,
+    dppy_lowerer.py,

--- a/.flake8
+++ b/.flake8
@@ -9,6 +9,8 @@ per-file-ignores =
     dpnp_randomimpl.py: F811
     # module level import not at top of file
     device_init.py: E402
+    # 'from . import *' used; unable to detect undefined names
+    __init__.py: F403
 exclude =
     .git,
     __pycache__,

--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,8 @@ per-file-ignores =
     device_init.py: E402
     # 'from . import *' used; unable to detect undefined names
     __init__.py: F403
+    # module level import not at top of file
+    target.py: E402
 exclude =
     .git,
     __pycache__,

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 tags
 MANIFEST
 
+.tmp/
 build/
 docs/_build/
 docs/gh-pages/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,7 @@ repos:
     rev: 3.9.1
     hooks:
     -   id: flake8
+-   repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.7.2
+    hooks:
+    -   id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,6 @@ repos:
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 21.4b2
-    hooks:
-    -   id: black
-        exclude: "versioneer.py|numba_dppy/_version.py"
 -   repo: https://github.com/pycqa/isort
     rev: 5.8.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     hooks:
     -   id: isort
         name: isort (python)
+        exclude: "dppy_lowerer.py"
     -   id: isort
         name: isort (cython)
         types: [cython]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "ms-python.python",
-    "timonwong.shellcheck"
+    "timonwong.shellcheck",
+    "eamodio.gitlens"
   ]
 }

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -5,8 +5,11 @@ set -euxo pipefail
 pytest -q -ra --disable-warnings --pyargs numba_dppy -vv
 
 if [[ -v ONEAPI_ROOT ]]; then
+    set +u
     # shellcheck disable=SC1091
     source "${ONEAPI_ROOT}/compiler/latest/env/vars.sh"
+    set -u
+
     export NUMBA_DPPY_LLVM_SPIRV_ROOT="${ONEAPI_ROOT}/compiler/latest/linux/bin"
     echo "Using llvm-spirv from oneAPI"
 else

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - pip:
     - pre-commit
     - flake8
-    - black
+    - black==20.8b1
 variables:
   CHANNELS: -c defaults -c numba -c intel -c numba/label/dev -c dppy/label/dev --override-channels
   CHANNELS_DEV: -c dppy/label/dev -c defaults -c numba -c intel -c numba/label/dev --override-channels

--- a/environment.yml
+++ b/environment.yml
@@ -19,8 +19,10 @@ dependencies:
   - packaging
   - pytest
   - pytest-xdist
+  - pip
   - pip:
     - pre-commit
+    - flake8
 variables:
   CHANNELS: -c defaults -c numba -c intel -c numba/label/dev -c dppy/label/dev --override-channels
   CHANNELS_DEV: -c dppy/label/dev -c defaults -c numba -c intel -c numba/label/dev --override-channels

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - pip:
     - pre-commit
     - flake8
+    - black
 variables:
   CHANNELS: -c defaults -c numba -c intel -c numba/label/dev -c dppy/label/dev --override-channels
   CHANNELS_DEV: -c dppy/label/dev -c defaults -c numba -c intel -c numba/label/dev --override-channels

--- a/numba_dppy/__init__.py
+++ b/numba_dppy/__init__.py
@@ -517,9 +517,9 @@ Supported NumPy Functions:
 
 import numba.testing
 
-from . import config
-
 from numba_dppy.retarget import offload_to_sycl_device
+
+from . import config
 
 if config.dppy_present:
     from .device_init import *

--- a/numba_dppy/codegen.py
+++ b/numba_dppy/codegen.py
@@ -14,12 +14,10 @@
 
 from llvmlite import binding as ll
 from llvmlite.llvmpy import core as lc
-
-from numba.core.codegen import CPUCodegen, CPUCodeLibrary
 from numba.core import utils
+from numba.core.codegen import CPUCodegen, CPUCodeLibrary
 
 from numba_dppy import config
-
 
 SPIR_TRIPLE = {32: " spir-unknown-unknown", 64: "spir64-unknown-unknown"}
 

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -18,7 +18,6 @@ from inspect import signature
 from types import FunctionType
 
 import dpctl
-import dpctl.memory as dpctl_mem
 import dpctl.program as dpctl_prog
 import numpy as np
 from numba.core import compiler, ir, types

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -653,7 +653,7 @@ class DPPYKernel(DPPYKernelBase):
                 msg += " %s |" % (key)
 
             msg = msg[:-1] + "]"
-            if access_type != None:
+            if access_type is not None:
                 print(msg)
             return True
         else:

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -29,9 +29,13 @@ from numba_dppy import config
 from numba_dppy.dppy_array_type import DPPYArray
 from numba_dppy.dppy_parfor_diagnostics import ExtendedParforDiagnostics
 from numba_dppy.driver import USMNdArrayType
-from numba_dppy.utils import (as_usm_obj, assert_no_return,
-                              copy_from_numpy_to_usm_obj,
-                              copy_to_numpy_from_usm_obj, has_usm_memory)
+from numba_dppy.utils import (
+    as_usm_obj,
+    assert_no_return,
+    copy_from_numpy_to_usm_obj,
+    copy_to_numpy_from_usm_obj,
+    has_usm_memory,
+)
 
 from . import spirv_generator
 from .dppy_passbuilder import DPPYPassBuilder

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -13,36 +13,29 @@
 # limitations under the License.
 
 import copy
-
-from .dppy_passbuilder import DPPYPassBuilder
-from numba.core.typing.templates import ConcreteTemplate
-from numba.core import types, compiler, ir
-from numba.core.typing.templates import AbstractTemplate
-from numba.core.compiler_lock import global_compiler_lock
 import ctypes
-from types import FunctionType
 from inspect import signature
+from types import FunctionType
 
 import dpctl
 import dpctl.memory as dpctl_mem
 import dpctl.program as dpctl_prog
 import numpy as np
+from numba.core import compiler, ir, types
+from numba.core.compiler import CompilerBase, DefaultPassBuilder
+from numba.core.compiler_lock import global_compiler_lock
+from numba.core.typing.templates import AbstractTemplate, ConcreteTemplate
+
+from numba_dppy import config
+from numba_dppy.dppy_array_type import DPPYArray
+from numba_dppy.dppy_parfor_diagnostics import ExtendedParforDiagnostics
+from numba_dppy.driver import USMNdArrayType
+from numba_dppy.utils import (as_usm_obj, assert_no_return,
+                              copy_from_numpy_to_usm_obj,
+                              copy_to_numpy_from_usm_obj, has_usm_memory)
 
 from . import spirv_generator
-
-from numba.core.compiler import DefaultPassBuilder, CompilerBase
-from numba_dppy.dppy_parfor_diagnostics import ExtendedParforDiagnostics
-from numba_dppy import config
-from numba_dppy.driver import USMNdArrayType
-from numba_dppy.dppy_array_type import DPPYArray
-from numba_dppy.utils import (
-    assert_no_return,
-    has_usm_memory,
-    as_usm_obj,
-    copy_from_numpy_to_usm_obj,
-    copy_to_numpy_from_usm_obj,
-)
-
+from .dppy_passbuilder import DPPYPassBuilder
 
 _NUMBA_DPPY_READ_ONLY = "read_only"
 _NUMBA_DPPY_WRITE_ONLY = "write_only"

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -14,8 +14,9 @@
 
 import os
 import warnings
-from packaging import version
+
 from numba.core import config
+from packaging import version
 
 
 class DpctlMinimumVersionRequiredError(Exception):

--- a/numba_dppy/decorators.py
+++ b/numba_dppy/decorators.py
@@ -15,15 +15,11 @@
 import dpctl
 from numba.core import sigutils, types
 
-from numba_dppy.utils import npytypes_array_to_dppy_array, assert_no_return
+from numba_dppy.utils import assert_no_return, npytypes_array_to_dppy_array
 
-from .compiler import (
-    compile_kernel,
-    JitDPPYKernel,
-    compile_dppy_func_template,
-    compile_dppy_func,
-    get_ordered_arg_access_types,
-)
+from .compiler import (JitDPPYKernel, compile_dppy_func,
+                       compile_dppy_func_template, compile_kernel,
+                       get_ordered_arg_access_types)
 
 
 def kernel(signature=None, access_types=None, debug=None):

--- a/numba_dppy/decorators.py
+++ b/numba_dppy/decorators.py
@@ -18,7 +18,7 @@ from numba.core import sigutils, types
 from numba_dppy.utils import assert_no_return, npytypes_array_to_dppy_array
 
 from .compiler import (JitDPPYKernel, compile_dppy_func,
-                       compile_dppy_func_template, compile_kernel,
+                       compile_dppy_func_template,
                        get_ordered_arg_access_types)
 
 

--- a/numba_dppy/decorators.py
+++ b/numba_dppy/decorators.py
@@ -17,9 +17,12 @@ from numba.core import sigutils, types
 
 from numba_dppy.utils import assert_no_return, npytypes_array_to_dppy_array
 
-from .compiler import (JitDPPYKernel, compile_dppy_func,
-                       compile_dppy_func_template,
-                       get_ordered_arg_access_types)
+from .compiler import (
+    JitDPPYKernel,
+    compile_dppy_func,
+    compile_dppy_func_template,
+    get_ordered_arg_access_types,
+)
 
 
 def kernel(signature=None, access_types=None, debug=None):

--- a/numba_dppy/descriptor.py
+++ b/numba_dppy/descriptor.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba.core import dispatcher, typing, utils
+from numba.core import utils
 from numba.core.cpu import CPUTargetOptions
 from numba.core.descriptors import TargetDescriptor
-from numba.core.options import TargetOptions
 
 from .target import DPPY_TARGET_NAME, DPPYTargetContext, DPPYTypingContext
 

--- a/numba_dppy/descriptor.py
+++ b/numba_dppy/descriptor.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from numba.core import dispatcher, typing, utils
+from numba.core.cpu import CPUTargetOptions
 from numba.core.descriptors import TargetDescriptor
 from numba.core.options import TargetOptions
 
-from numba.core import dispatcher, utils, typing
-from .target import DPPYTargetContext, DPPYTypingContext, DPPY_TARGET_NAME
-
-from numba.core.cpu import CPUTargetOptions
+from .target import DPPY_TARGET_NAME, DPPYTargetContext, DPPYTypingContext
 
 
 class DPPYTarget(TargetDescriptor):

--- a/numba_dppy/device_init.py
+++ b/numba_dppy/device_init.py
@@ -13,10 +13,22 @@
 # limitations under the License.
 
 # Re export
-from .ocl.stubs import (CLK_GLOBAL_MEM_FENCE, CLK_LOCAL_MEM_FENCE, atomic,
-                        barrier, get_global_id, get_global_size, get_group_id,
-                        get_local_id, get_local_size, get_num_groups,
-                        get_work_dim, local, mem_fence, sub_group_barrier)
+from .ocl.stubs import (
+    CLK_GLOBAL_MEM_FENCE,
+    CLK_LOCAL_MEM_FENCE,
+    atomic,
+    barrier,
+    get_global_id,
+    get_global_size,
+    get_group_id,
+    get_local_id,
+    get_local_size,
+    get_num_groups,
+    get_work_dim,
+    local,
+    mem_fence,
+    sub_group_barrier,
+)
 
 """
 We are importing dpnp stub module to make Numba recognize the

--- a/numba_dppy/device_init.py
+++ b/numba_dppy/device_init.py
@@ -13,22 +13,10 @@
 # limitations under the License.
 
 # Re export
-from .ocl.stubs import (
-    get_global_id,
-    get_global_size,
-    get_local_id,
-    get_local_size,
-    get_group_id,
-    get_work_dim,
-    get_num_groups,
-    barrier,
-    mem_fence,
-    sub_group_barrier,
-    atomic,
-    local,
-    CLK_LOCAL_MEM_FENCE,
-    CLK_GLOBAL_MEM_FENCE,
-)
+from .ocl.stubs import (CLK_GLOBAL_MEM_FENCE, CLK_LOCAL_MEM_FENCE, atomic,
+                        barrier, get_global_id, get_global_size, get_group_id,
+                        get_local_id, get_local_size, get_num_groups,
+                        get_work_dim, local, mem_fence, sub_group_barrier)
 
 """
 We are importing dpnp stub module to make Numba recognize the
@@ -38,11 +26,10 @@ from .dpnp_glue.stubs import dpnp
 
 DEFAULT_LOCAL_SIZE = []
 
-from . import initialize
-
-from .decorators import kernel, func, autojit
 import dpctl
-from . import target
+
+from . import initialize, target
+from .decorators import autojit, func, kernel
 
 
 def is_available():

--- a/numba_dppy/dpnp_glue/dpnp_array_creations_impl.py
+++ b/numba_dppy/dpnp_glue/dpnp_array_creations_impl.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba import types
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
 import numpy as np
-from numba_dppy import dpctl_functions
+from numba import types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
 import numba_dppy
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
+from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @register_jitable

--- a/numba_dppy/dpnp_glue/dpnp_array_ops_impl.py
+++ b/numba_dppy/dpnp_glue/dpnp_array_ops_impl.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba import types
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
 import numpy as np
-from numba_dppy import dpctl_functions
+from numba import types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
 import numba_dppy
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
+from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @register_jitable

--- a/numba_dppy/dpnp_glue/dpnp_fptr_interface.pyx
+++ b/numba_dppy/dpnp_glue/dpnp_fptr_interface.pyx
@@ -260,8 +260,9 @@ cdef DPNPFuncType get_DPNPFuncType_from_str(name):
     else:
         return DPNPFuncType.DPNP_FT_NONE
 
-from libc.stdio cimport printf
 from libc.stdint cimport uintptr_t
+from libc.stdio cimport printf
+
 
 cpdef get_dpnp_fn_ptr(name, types):
     cdef DPNPFuncName func_name = get_DPNPFuncName_from_str(name)

--- a/numba_dppy/dpnp_glue/dpnp_indexing.py
+++ b/numba_dppy/dpnp_glue/dpnp_indexing.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba import types
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
 import numpy as np
+from numba import types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
 from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @overload(stubs.dpnp.diagonal)

--- a/numba_dppy/dpnp_glue/dpnp_linalgimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_linalgimpl.py
@@ -570,9 +570,9 @@ def dpnp_matrix_rank_impl(M, tol=None, hermitian=False):
     PRINT_DEBUG = dpnp_lowering.DEBUG
 
     def dpnp_impl(M, tol=None, hermitian=False):
-        if tol != None:
+        if tol is not None:
             raise ValueError("tol is not supported for np.linalg.matrix_rank(M)")
-        if hermitian == True:
+        if hermitian:
             raise ValueError("hermitian is not supported for np.linalg.matrix_rank(M)")
 
         if M.ndim > 2:

--- a/numba_dppy/dpnp_glue/dpnp_linalgimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_linalgimpl.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba import types
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
 import numpy as np
-from numba_dppy import dpctl_functions
+from numba import types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
 import numba_dppy
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
+from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @overload(stubs.dpnp.eig)

--- a/numba_dppy/dpnp_glue/dpnp_logic.py
+++ b/numba_dppy/dpnp_glue/dpnp_logic.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 from numba import types
-from numba.core.extending import overload, register_jitable
+from numba.core.extending import overload
 from numba.core.typing import signature
 
 import numba_dppy.dpnp_glue as dpnp_lowering

--- a/numba_dppy/dpnp_glue/dpnp_logic.py
+++ b/numba_dppy/dpnp_glue/dpnp_logic.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba import types
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
 import numpy as np
+from numba import types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
 from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @overload(stubs.dpnp.all)

--- a/numba_dppy/dpnp_glue/dpnp_manipulation.py
+++ b/numba_dppy/dpnp_glue/dpnp_manipulation.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba import types
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
 import numpy as np
+from numba import types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
 from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @overload(stubs.dpnp.repeat)

--- a/numba_dppy/dpnp_glue/dpnp_randomimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_randomimpl.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import numpy as np
 from numba import types
 from numba.core.extending import overload, register_jitable

--- a/numba_dppy/dpnp_glue/dpnp_randomimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_randomimpl.py
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba import types
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
-import numpy as np
-from numba_dppy import dpctl_functions
 import os
+
+import numpy as np
+from numba import types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
+from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @register_jitable

--- a/numba_dppy/dpnp_glue/dpnp_sort_search_countimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_sort_search_countimpl.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba.core import types, cgutils
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
 import numpy as np
+from numba.core import cgutils, types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
 import numba_dppy
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
 from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @overload(stubs.dpnp.argmax)

--- a/numba_dppy/dpnp_glue/dpnp_statisticsimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_statisticsimpl.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba.core import types, cgutils
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
 import numpy as np
+from numba.core import cgutils, types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
 from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @overload(stubs.dpnp.max)

--- a/numba_dppy/dpnp_glue/dpnp_statisticsimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_statisticsimpl.py
@@ -246,7 +246,7 @@ def dpnp_median_impl(a):
 
     Function declaration:
     void custom_median_c(void* array1_in, void* result1, const size_t* shape,
-			 size_t ndim, const size_t* axis, size_t naxis)
+                         size_t ndim, const size_t* axis, size_t naxis)
 
     We are using void * in case of size_t * as Numba currently does not have
     any type to represent size_t *. Since, both the types are pointers,

--- a/numba_dppy/dpnp_glue/dpnp_transcendentalsimpl.py
+++ b/numba_dppy/dpnp_glue/dpnp_transcendentalsimpl.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
-from numba import types
-from numba.core.typing import signature
-from . import stubs
-import numba_dppy.dpnp_glue as dpnp_lowering
-from numba.core.extending import overload, register_jitable
 import numpy as np
-from numba_dppy import dpctl_functions
+from numba import types
+from numba.core.extending import overload, register_jitable
+from numba.core.typing import signature
+
 import numba_dppy
+import numba_dppy.dpnp_glue as dpnp_lowering
+import numba_dppy.dpnp_glue.dpnpimpl as dpnp_ext
+from numba_dppy import dpctl_functions
+
+from . import stubs
 
 
 @register_jitable

--- a/numba_dppy/dpnp_glue/dpnpdecl.py
+++ b/numba_dppy/dpnp_glue/dpnpdecl.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from numba import types
-from numba.core.types.misc import RawPointer
 from numba.core.typing.templates import AttributeTemplate, infer_getattr
 
 import numba_dppy

--- a/numba_dppy/dpnp_glue/dpnpdecl.py
+++ b/numba_dppy/dpnp_glue/dpnpdecl.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba.core.typing.templates import AttributeTemplate, infer_getattr
-import numba_dppy
 from numba import types
 from numba.core.types.misc import RawPointer
+from numba.core.typing.templates import AttributeTemplate, infer_getattr
+
+import numba_dppy
 
 
 @infer_getattr

--- a/numba_dppy/dpnp_glue/dpnpimpl.py
+++ b/numba_dppy/dpnp_glue/dpnpimpl.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba.core.imputils import lower_builtin
-from numba.core import types
-from numba.core.extending import register_jitable
 import numpy as np
 from llvmlite import ir
-from numba.core.imputils import lower_getattr
+from numba.core import types
+from numba.core.extending import register_jitable
+from numba.core.imputils import lower_builtin, lower_getattr
 from numba.cpython import listobj
-
 
 ll_void_p = ir.IntType(8).as_pointer()
 

--- a/numba_dppy/dpnp_glue/dpnpimpl.py
+++ b/numba_dppy/dpnp_glue/dpnpimpl.py
@@ -59,7 +59,7 @@ pass around.
 
 
 @lower_getattr(types.Array, "shapeptr")
-def array_shape(context, builder, typ, value):
+def array_shapeptr(context, builder, typ, value):
     shape_ptr = builder.gep(
         value.operands[0],
         [context.get_constant(types.int32, 0), context.get_constant(types.int32, 5)],
@@ -69,7 +69,7 @@ def array_shape(context, builder, typ, value):
 
 
 @lower_getattr(types.List, "size")
-def list_itemsize(context, builder, typ, value):
+def list_size(context, builder, typ, value):
     inst = listobj.ListInstance(context, builder, typ, value)
     return inst.size
 
@@ -81,6 +81,6 @@ def list_itemsize(context, builder, typ, value):
 
 
 @lower_getattr(types.List, "ctypes")
-def list_itemsize(context, builder, typ, value):
+def list_ctypes(context, builder, typ, value):
     inst = listobj.ListInstance(context, builder, typ, value)
     return builder.bitcast(inst.data, ll_void_p)

--- a/numba_dppy/dpnp_glue/dpnpimpl.py
+++ b/numba_dppy/dpnp_glue/dpnpimpl.py
@@ -16,7 +16,7 @@ import numpy as np
 from llvmlite import ir
 from numba.core import types
 from numba.core.extending import register_jitable
-from numba.core.imputils import lower_builtin, lower_getattr
+from numba.core.imputils import lower_getattr
 from numba.cpython import listobj
 
 ll_void_p = ir.IntType(8).as_pointer()

--- a/numba_dppy/dppy_array_type.py
+++ b/numba_dppy/dppy_array_type.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba.core.types.npytypes import Array
+import numpy as np
 from numba.core import types
 from numba.core.datamodel.models import StructModel
-import numpy as np
+from numba.core.types.npytypes import Array
 
 
 class DPPYArray(Array):

--- a/numba_dppy/dppy_debuginfo.py
+++ b/numba_dppy/dppy_debuginfo.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba.core.debuginfo import DIBuilder
 from llvmlite import ir
+from numba.core.debuginfo import DIBuilder
 
 
 class DPPYDIBuilder(DIBuilder):

--- a/numba_dppy/dppy_offload_dispatcher.py
+++ b/numba_dppy/dppy_offload_dispatcher.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba.core import dispatcher, compiler
+from numba.core import compiler, dispatcher
 from numba.core.registry import cpu_target
 from numba.core.target_extension import dispatcher_registry, target_registry
+
 import numba_dppy.config as dppy_config
 from numba_dppy.target import DPPY_TARGET_NAME
 

--- a/numba_dppy/dppy_passbuilder.py
+++ b/numba_dppy/dppy_passbuilder.py
@@ -13,25 +13,43 @@
 # limitations under the License.
 
 from numba.core.compiler_machinery import PassManager
-from numba.core.typed_passes import (AnnotateTypes, InlineOverloads,
-                                     IRLegalization, NopythonRewrites,
-                                     NoPythonSupportedFeatureValidation,
-                                     NopythonTypeInference, PreLowerStripPhis)
-from numba.core.untyped_passes import (DeadBranchPrune, FindLiterallyCalls,
-                                       FixupArgs, GenericRewrites,
-                                       InlineClosureLikes, InlineInlinables,
-                                       IRProcessing, LiteralUnroll,
-                                       MakeFunctionToJitFunction,
-                                       ReconstructSSA,
-                                       RewriteSemanticConstants,
-                                       TranslateByteCode, WithLifting)
+from numba.core.typed_passes import (
+    AnnotateTypes,
+    InlineOverloads,
+    IRLegalization,
+    NopythonRewrites,
+    NoPythonSupportedFeatureValidation,
+    NopythonTypeInference,
+    PreLowerStripPhis,
+)
+from numba.core.untyped_passes import (
+    DeadBranchPrune,
+    FindLiterallyCalls,
+    FixupArgs,
+    GenericRewrites,
+    InlineClosureLikes,
+    InlineInlinables,
+    IRProcessing,
+    LiteralUnroll,
+    MakeFunctionToJitFunction,
+    ReconstructSSA,
+    RewriteSemanticConstants,
+    TranslateByteCode,
+    WithLifting,
+)
 
-from .dppy_passes import (DPPYConstantSizeStaticLocalMemoryPass,
-                          DPPYDumpParforDiagnostics, DPPYNoPythonBackend,
-                          DPPYParforPass, DPPYPreParforPass,
-                          SpirvFriendlyLowering)
-from .rename_numpy_functions_pass import (DPPYRewriteNdarrayFunctions,
-                                          DPPYRewriteOverloadedNumPyFunctions)
+from .dppy_passes import (
+    DPPYConstantSizeStaticLocalMemoryPass,
+    DPPYDumpParforDiagnostics,
+    DPPYNoPythonBackend,
+    DPPYParforPass,
+    DPPYPreParforPass,
+    SpirvFriendlyLowering,
+)
+from .rename_numpy_functions_pass import (
+    DPPYRewriteNdarrayFunctions,
+    DPPYRewriteOverloadedNumPyFunctions,
+)
 
 
 class DPPYPassBuilder(object):

--- a/numba_dppy/dppy_passbuilder.py
+++ b/numba_dppy/dppy_passbuilder.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 from numba.core.compiler_machinery import PassManager
-from numba.core.typed_passes import (AnnotateTypes, DumpParforDiagnostics,
+from numba.core.typed_passes import (AnnotateTypes,
                                      InlineOverloads, IRLegalization,
                                      NopythonRewrites,
                                      NoPythonSupportedFeatureValidation,
-                                     NopythonTypeInference, ParforPass,
-                                     PreLowerStripPhis, PreParforPass)
-from numba.core.untyped_passes import (CanonicalizeLoopEntry,
-                                       CanonicalizeLoopExit, DeadBranchPrune,
-                                       ExtractByteCode, FindLiterallyCalls,
+                                     NopythonTypeInference,
+                                     PreLowerStripPhis)
+from numba.core.untyped_passes import (DeadBranchPrune,
+                                       FindLiterallyCalls,
                                        FixupArgs, GenericRewrites,
                                        InlineClosureLikes, InlineInlinables,
                                        IRProcessing, LiteralUnroll,

--- a/numba_dppy/dppy_passbuilder.py
+++ b/numba_dppy/dppy_passbuilder.py
@@ -13,52 +13,29 @@
 # limitations under the License.
 
 from numba.core.compiler_machinery import PassManager
+from numba.core.typed_passes import (AnnotateTypes, DumpParforDiagnostics,
+                                     InlineOverloads, IRLegalization,
+                                     NopythonRewrites,
+                                     NoPythonSupportedFeatureValidation,
+                                     NopythonTypeInference, ParforPass,
+                                     PreLowerStripPhis, PreParforPass)
+from numba.core.untyped_passes import (CanonicalizeLoopEntry,
+                                       CanonicalizeLoopExit, DeadBranchPrune,
+                                       ExtractByteCode, FindLiterallyCalls,
+                                       FixupArgs, GenericRewrites,
+                                       InlineClosureLikes, InlineInlinables,
+                                       IRProcessing, LiteralUnroll,
+                                       MakeFunctionToJitFunction,
+                                       ReconstructSSA,
+                                       RewriteSemanticConstants,
+                                       TranslateByteCode, WithLifting)
 
-from numba.core.untyped_passes import (
-    ExtractByteCode,
-    TranslateByteCode,
-    FixupArgs,
-    IRProcessing,
-    DeadBranchPrune,
-    RewriteSemanticConstants,
-    InlineClosureLikes,
-    GenericRewrites,
-    WithLifting,
-    InlineInlinables,
-    FindLiterallyCalls,
-    MakeFunctionToJitFunction,
-    CanonicalizeLoopExit,
-    CanonicalizeLoopEntry,
-    ReconstructSSA,
-    LiteralUnroll,
-)
-
-from numba.core.typed_passes import (
-    NopythonTypeInference,
-    AnnotateTypes,
-    NopythonRewrites,
-    PreParforPass,
-    ParforPass,
-    DumpParforDiagnostics,
-    IRLegalization,
-    InlineOverloads,
-    PreLowerStripPhis,
-    NoPythonSupportedFeatureValidation,
-)
-
-from .dppy_passes import (
-    DPPYConstantSizeStaticLocalMemoryPass,
-    DPPYPreParforPass,
-    DPPYParforPass,
-    SpirvFriendlyLowering,
-    DPPYNoPythonBackend,
-    DPPYDumpParforDiagnostics,
-)
-
-from .rename_numpy_functions_pass import (
-    DPPYRewriteOverloadedNumPyFunctions,
-    DPPYRewriteNdarrayFunctions,
-)
+from .dppy_passes import (DPPYConstantSizeStaticLocalMemoryPass,
+                          DPPYDumpParforDiagnostics, DPPYNoPythonBackend,
+                          DPPYParforPass, DPPYPreParforPass,
+                          SpirvFriendlyLowering)
+from .rename_numpy_functions_pass import (DPPYRewriteNdarrayFunctions,
+                                          DPPYRewriteOverloadedNumPyFunctions)
 
 
 class DPPYPassBuilder(object):

--- a/numba_dppy/dppy_passbuilder.py
+++ b/numba_dppy/dppy_passbuilder.py
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 from numba.core.compiler_machinery import PassManager
-from numba.core.typed_passes import (AnnotateTypes,
-                                     InlineOverloads, IRLegalization,
-                                     NopythonRewrites,
+from numba.core.typed_passes import (AnnotateTypes, InlineOverloads,
+                                     IRLegalization, NopythonRewrites,
                                      NoPythonSupportedFeatureValidation,
-                                     NopythonTypeInference,
-                                     PreLowerStripPhis)
-from numba.core.untyped_passes import (DeadBranchPrune,
-                                       FindLiterallyCalls,
+                                     NopythonTypeInference, PreLowerStripPhis)
+from numba.core.untyped_passes import (DeadBranchPrune, FindLiterallyCalls,
                                        FixupArgs, GenericRewrites,
                                        InlineClosureLikes, InlineInlinables,
                                        IRProcessing, LiteralUnroll,

--- a/numba_dppy/dppy_passes.py
+++ b/numba_dppy/dppy_passes.py
@@ -20,12 +20,19 @@ from contextlib import contextmanager
 
 import numba
 import numpy as np
-from numba.core import (errors, funcdesc, ir, lowering, types, typing,
-                        utils)
-from numba.core.compiler_machinery import (AnalysisPass, FunctionPass,
-                                           LoweringPass, register_pass)
-from numba.core.errors import (LiteralTypingError, LoweringError, TypingError,
-                               new_error_context)
+from numba.core import errors, funcdesc, ir, lowering, types, typing, utils
+from numba.core.compiler_machinery import (
+    AnalysisPass,
+    FunctionPass,
+    LoweringPass,
+    register_pass,
+)
+from numba.core.errors import (
+    LiteralTypingError,
+    LoweringError,
+    TypingError,
+    new_error_context,
+)
 from numba.core.ir_utils import remove_dels
 from numba.parfors.parfor import Parfor
 from numba.parfors.parfor import ParforPass as _parfor_ParforPass

--- a/numba_dppy/dppy_passes.py
+++ b/numba_dppy/dppy_passes.py
@@ -12,50 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import contextmanager
-import warnings
-
-import numpy as np
-import numba
-from numba.core import ir, lowering
-import weakref
-from collections import namedtuple, deque
 import operator
+import warnings
+import weakref
+from collections import deque, namedtuple
+from contextlib import contextmanager
 
-from numba.core import (
-    config,
-    errors,
-    funcdesc,
-    utils,
-    typing,
-    types,
-)
-
+import numba
+import numpy as np
+from numba.core import (config, errors, funcdesc, ir, lowering, types, typing,
+                        utils)
+from numba.core.compiler_machinery import (AnalysisPass, FunctionPass,
+                                           LoweringPass, register_pass)
+from numba.core.errors import (LiteralTypingError, LoweringError, TypingError,
+                               new_error_context)
 from numba.core.ir_utils import remove_dels
-
-from numba.core.errors import (
-    LoweringError,
-    new_error_context,
-    TypingError,
-    LiteralTypingError,
-)
-
-from numba.core.compiler_machinery import (
-    FunctionPass,
-    LoweringPass,
-    register_pass,
-    AnalysisPass,
-)
-
-from numba.parfors.parfor import (
-    PreParforPass as _parfor_PreParforPass,
-    swap_functions_map,
-)
-from numba.parfors.parfor import ParforPass as _parfor_ParforPass
 from numba.parfors.parfor import Parfor
+from numba.parfors.parfor import ParforPass as _parfor_ParforPass
+from numba.parfors.parfor import PreParforPass as _parfor_PreParforPass
+from numba.parfors.parfor import swap_functions_map
+
+from numba_dppy import config
 
 from .dppy_lowerer import DPPYLower
-from numba_dppy import config
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)

--- a/numba_dppy/dppy_passes.py
+++ b/numba_dppy/dppy_passes.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 
 import numba
 import numpy as np
-from numba.core import (config, errors, funcdesc, ir, lowering, types, typing,
+from numba.core import (errors, funcdesc, ir, lowering, types, typing,
                         utils)
 from numba.core.compiler_machinery import (AnalysisPass, FunctionPass,
                                            LoweringPass, register_pass)

--- a/numba_dppy/driver/dpctl_capi_fn_builder.py
+++ b/numba_dppy/driver/dpctl_capi_fn_builder.py
@@ -18,7 +18,6 @@ declarations into an LLVM module.
 """
 
 import llvmlite.llvmpy.core as lc
-from llvmlite.ir import builder
 from numba.core import cgutils, types
 
 import numba_dppy.utils as utils

--- a/numba_dppy/driver/dpctl_capi_fn_builder.py
+++ b/numba_dppy/driver/dpctl_capi_fn_builder.py
@@ -19,7 +19,7 @@ declarations into an LLVM module.
 
 import llvmlite.llvmpy.core as lc
 from llvmlite.ir import builder
-from numba.core import types, cgutils
+from numba.core import cgutils, types
 
 import numba_dppy.utils as utils
 

--- a/numba_dppy/driver/usm_ndarray_type.py
+++ b/numba_dppy/driver/usm_ndarray_type.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba.extending import typeof_impl, register_model
-from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
-import numba_dppy.target as dppy_target
 from dpctl.tensor import usm_ndarray
+from numba.extending import register_model, typeof_impl
 from numba.np import numpy_support
+
+import numba_dppy.target as dppy_target
+from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
 from numba_dppy.utils import address_space
 
 

--- a/numba_dppy/dufunc_inliner.py
+++ b/numba_dppy/dufunc_inliner.py
@@ -31,7 +31,8 @@ def _run_inliner(
     typingctx,
     targetctx,
 ):
-    from numba.core.inline_closurecall import inline_closure_call, callee_ir_validator
+    from numba.core.inline_closurecall import (callee_ir_validator,
+                                               inline_closure_call)
 
     # pass is typed so use the callee globals
     inline_closure_call(

--- a/numba_dppy/dufunc_inliner.py
+++ b/numba_dppy/dufunc_inliner.py
@@ -31,8 +31,7 @@ def _run_inliner(
     typingctx,
     targetctx,
 ):
-    from numba.core.inline_closurecall import (callee_ir_validator,
-                                               inline_closure_call)
+    from numba.core.inline_closurecall import callee_ir_validator, inline_closure_call
 
     # pass is typed so use the callee globals
     inline_closure_call(

--- a/numba_dppy/dufunc_inliner.py
+++ b/numba_dppy/dufunc_inliner.py
@@ -86,7 +86,6 @@ def _inline(
         return False
 
     sig = calltypes[expr]
-    is_method = False
 
     templates = getattr(func_ty, "templates", None)
     arg_typs = sig.args

--- a/numba_dppy/examples/atomic_op.py
+++ b/numba_dppy/examples/atomic_op.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 
 def main():

--- a/numba_dppy/examples/auto_offload_examples/sum-1d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-1d.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba import njit
-import numpy as np
 import dpctl
+import numpy as np
+from numba import njit
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/examples/auto_offload_examples/sum-2d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-2d.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba import njit, gdb
-import numpy as np
 import dpctl
+import numpy as np
+from numba import gdb, njit
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/examples/auto_offload_examples/sum-3d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-3d.py
@@ -14,7 +14,7 @@
 
 import dpctl
 import numpy as np
-from numba import gdb, njit
+from numba import njit
 
 import numba_dppy as dppy
 

--- a/numba_dppy/examples/auto_offload_examples/sum-3d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-3d.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba import njit, gdb
-import numpy as np
 import dpctl
+import numpy as np
+from numba import gdb, njit
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/examples/auto_offload_examples/sum-4d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-4d.py
@@ -49,7 +49,7 @@ def main():
     for i in range(N):
         for j in range(N):
             for k in range(N):
-                for l in range(N):
+                for l in range(N):  # noqa
                     if c[i, j, k, l] != 2.0:
                         print("First index not equal to 2.0 was", i, j, k, l)
                         break

--- a/numba_dppy/examples/auto_offload_examples/sum-4d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-4d.py
@@ -14,7 +14,7 @@
 
 import dpctl
 import numpy as np
-from numba import gdb, njit
+from numba import njit
 
 import numba_dppy as dppy
 

--- a/numba_dppy/examples/auto_offload_examples/sum-4d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-4d.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba import njit, gdb
-import numpy as np
 import dpctl
+import numpy as np
+from numba import gdb, njit
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/examples/auto_offload_examples/sum-5d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-5d.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba import njit, gdb
-import numpy as np
 import dpctl
+import numpy as np
+from numba import gdb, njit
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/examples/auto_offload_examples/sum-5d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-5d.py
@@ -49,7 +49,7 @@ def main():
     for i in range(N):
         for j in range(N):
             for k in range(N):
-                for l in range(N):
+                for l in range(N):  # noqa
                     for m in range(N):
                         if c[i, j, k, l, m] != 2.0:
                             print("First index not equal to 2.0 was", i, j, k, l, m)

--- a/numba_dppy/examples/barrier.py
+++ b/numba_dppy/examples/barrier.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dpctl
 import numpy as np
 from numba import float32
+
 import numba_dppy as dppy
-import dpctl
 
 
 def no_arg_barrier_support():

--- a/numba_dppy/examples/blacksholes_kernel.py
+++ b/numba_dppy/examples/blacksholes_kernel.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-import time
 
 import dpctl
 import numpy as np

--- a/numba_dppy/examples/blacksholes_kernel.py
+++ b/numba_dppy/examples/blacksholes_kernel.py
@@ -92,7 +92,6 @@ def main():
     device.print_device_info()
 
     with dppy.offload_to_sycl_device(device):
-        time1 = time.time()
         for i in range(iterations):
             black_scholes_dppy[blockdim, griddim](
                 callResult,

--- a/numba_dppy/examples/blacksholes_kernel.py
+++ b/numba_dppy/examples/blacksholes_kernel.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import math
 import time
-import numba_dppy as dppy
-import dpctl
 
+import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 RISKFREE = 0.02
 VOLATILITY = 0.30

--- a/numba_dppy/examples/blacksholes_njit.py
+++ b/numba_dppy/examples/blacksholes_njit.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
+import math
+import time
+
 import dpctl
 import numba
 import numpy as np
-import math
-import argparse
-import time
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/examples/debug/dppy_func.py
+++ b/numba_dppy/examples/debug/dppy_func.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 
 @dppy.func(debug=True)

--- a/numba_dppy/examples/debug/simple_dppy_func.py
+++ b/numba_dppy/examples/debug/simple_dppy_func.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 
 @dppy.func(debug=True)

--- a/numba_dppy/examples/debug/simple_sum.py
+++ b/numba_dppy/examples/debug/simple_sum.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 
 @dppy.kernel(debug=True)

--- a/numba_dppy/examples/debug/sum.py
+++ b/numba_dppy/examples/debug/sum.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 
 @dppy.kernel(debug=True)

--- a/numba_dppy/examples/debug/sum_local_vars.py
+++ b/numba_dppy/examples/debug/sum_local_vars.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.import numpy as np
 
-import numpy as np
-import numba_dppy as dppy
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 
 @dppy.kernel(debug=True)

--- a/numba_dppy/examples/debug/sum_local_vars_revive.py
+++ b/numba_dppy/examples/debug/sum_local_vars_revive.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.import numpy as np
 
-import numpy as np
-import numba_dppy as dppy
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 
 @dppy.func

--- a/numba_dppy/examples/dppy_func.py
+++ b/numba_dppy/examples/dppy_func.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 
 @dppy.func

--- a/numba_dppy/examples/dppy_with_context.py
+++ b/numba_dppy/examples/dppy_with_context.py
@@ -24,9 +24,10 @@ functionality. Note that numba_dppy should be installed in your
 environment for the example to work.
 """
 
+import dpctl
 import numpy as np
 from numba import njit, prange
-import dpctl
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/examples/matmul.py
+++ b/numba_dppy/examples/matmul.py
@@ -14,9 +14,11 @@
 # limitations under the License.
 
 from timeit import default_timer as time
-import numpy as np
-import numba_dppy as dppy
+
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
 
 
 @dppy.kernel

--- a/numba_dppy/examples/matmul.py
+++ b/numba_dppy/examples/matmul.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from timeit import default_timer as time
-
 import dpctl
 import numpy as np
 

--- a/numba_dppy/examples/pairwise_distance.py
+++ b/numba_dppy/examples/pairwise_distance.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from time import time
-from math import sqrt
-import numpy as np
 import argparse
-import numba_dppy as dppy
+from math import sqrt
+from time import time
+
 import dpctl
 import dpctl.memory as dpctl_mem
+import numpy as np
+
+import numba_dppy as dppy
 
 parser = argparse.ArgumentParser(description="Program to compute pairwise distance")
 

--- a/numba_dppy/examples/rand.py
+++ b/numba_dppy/examples/rand.py
@@ -20,9 +20,10 @@ this feature is also available by simply invoking a ``numba.jit`` function with
 the numpy.random calls from within a ``numba_dppy.offload_to_sycl_device``scope.
 """
 
+import dpctl
 import numba
 import numpy as np
-import dpctl
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/examples/sum.py
+++ b/numba_dppy/examples/sum.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 
 import dpctl
-import numpy.testing as testing
-import numba_dppy as dppy
 import numpy as np
+import numpy.testing as testing
+
+import numba_dppy as dppy
 
 
 @dppy.kernel

--- a/numba_dppy/examples/sum2D.py
+++ b/numba_dppy/examples/sum2D.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 import dpctl
-import numba_dppy as dppy
 import numpy as np
+
+import numba_dppy as dppy
 
 
 @dppy.kernel

--- a/numba_dppy/examples/sum_ndarray.py
+++ b/numba_dppy/examples/sum_ndarray.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from _helper import has_cpu, has_gpu
-import numpy as np
-import numba_dppy as dppy
 import dpctl
+import numpy as np
+from _helper import has_cpu, has_gpu
+
+import numba_dppy as dppy
 
 
 @dppy.kernel(

--- a/numba_dppy/examples/sum_reduction.py
+++ b/numba_dppy/examples/sum_reduction.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dpctl
 import math
+
+import dpctl
 import numpy as np
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/examples/sum_reduction_ocl.py
+++ b/numba_dppy/examples/sum_reduction_ocl.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import dpctl
-from numba import int32
-import numba_dppy as dppy
 import numpy as np
+from numba import int32
+
+import numba_dppy as dppy
 
 
 @dppy.kernel

--- a/numba_dppy/examples/sum_reduction_recursive_ocl.py
+++ b/numba_dppy/examples/sum_reduction_recursive_ocl.py
@@ -20,9 +20,10 @@ partial reductions in separate kernels.
 
 import dpctl
 import dpctl.memory as dpctl_mem
-from numba import int32
-import numba_dppy as dppy
 import numpy as np
+from numba import int32
+
+import numba_dppy as dppy
 
 
 @dppy.kernel

--- a/numba_dppy/examples/usm_ndarray.py
+++ b/numba_dppy/examples/usm_ndarray.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 import dpctl
-import numpy.testing as testing
-import numba_dppy as dppy
-import numpy as np
-
 import dpctl.tensor as dpt
+import numpy as np
+import numpy.testing as testing
+
+import numba_dppy as dppy
 
 
 @dppy.kernel

--- a/numba_dppy/examples/vectorize.py
+++ b/numba_dppy/examples/vectorize.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-from numba import vectorize, float64
 import dpctl
+import numpy as np
+from numba import float64, vectorize
+
 import numba_dppy as dppy
 
 

--- a/numba_dppy/initialize.py
+++ b/numba_dppy/initialize.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import llvmlite.binding as ll
 import os
-from numba_dppy.vectorizers import DPPYVectorize
+
+import llvmlite.binding as ll
 from numba.np.ufunc.decorators import Vectorize
+
+from numba_dppy.vectorizers import DPPYVectorize
 
 
 def init_jit():
@@ -35,9 +37,10 @@ def load_dpctl_sycl_interface():
     Raises:
         ImportError: If the ``DPCTLSyclInterface`` library could not be loaded.
     """
-    import dpctl
     import glob
     import platform as plt
+
+    import dpctl
 
     platform = plt.system()
     if platform == "Windows":

--- a/numba_dppy/numpy_usm_shared.py
+++ b/numba_dppy/numpy_usm_shared.py
@@ -32,19 +32,27 @@ from dpctl.tensor.numpy_usm_shared import class_list, functions_list, ndarray
 from llvmlite import ir
 from numba import types
 from numba.core import cgutils, config, types, typing
-from numba.core.datamodel.registry import \
-    register_default as register_model_default
+from numba.core.datamodel.registry import register_default as register_model_default
 from numba.core.imputils import builtin_registry as lower_registry
 from numba.core.overload_glue import _overload_glue
 from numba.core.pythonapi import box
 from numba.core.typing.arraydecl import normalize_shape
 from numba.core.typing.npydecl import registry as typing_registry
-from numba.core.typing.templates import (AttributeTemplate, CallableTemplate,
-                                         bound_function)
+from numba.core.typing.templates import (
+    AttributeTemplate,
+    CallableTemplate,
+    bound_function,
+)
 from numba.core.typing.templates import builtin_registry as templates_registry
 from numba.core.typing.templates import signature
-from numba.extending import (intrinsic, lower_builtin, overload_classmethod,
-                             register_model, type_callable, typeof_impl)
+from numba.extending import (
+    intrinsic,
+    lower_builtin,
+    overload_classmethod,
+    register_model,
+    type_callable,
+    typeof_impl,
+)
 from numba.np import numpy_support
 from numba.np.arrayobj import _array_copy
 

--- a/numba_dppy/numpy_usm_shared.py
+++ b/numba_dppy/numpy_usm_shared.py
@@ -14,43 +14,41 @@
 
 import builtins
 import functools
-import importlib
 import inspect
 import sys
-from ctypes.util import find_library
-from inspect import getmembers, isbuiltin, isclass, isfunction
-from numbers import Number
 from types import BuiltinFunctionType as bftype
 from types import FunctionType as ftype
 
 import dpctl.tensor.numpy_usm_shared as nus
 import llvmlite.binding as llb
-import llvmlite.llvmpy.core as lc
 import numba
 import numpy as np
-from dpctl.tensor.numpy_usm_shared import class_list, functions_list, ndarray
+from dpctl.tensor.numpy_usm_shared import functions_list, ndarray
 from llvmlite import ir
-from numba import types
 from numba.core import cgutils, config, types, typing
-from numba.core.datamodel.registry import \
-    register_default as register_model_default
 from numba.core.imputils import builtin_registry as lower_registry
 from numba.core.overload_glue import _overload_glue
 from numba.core.pythonapi import box
 from numba.core.typing.arraydecl import normalize_shape
 from numba.core.typing.npydecl import registry as typing_registry
-from numba.core.typing.templates import (AttributeTemplate, CallableTemplate,
-                                         bound_function)
+from numba.core.typing.templates import (
+    AttributeTemplate,
+    CallableTemplate,
+    bound_function,
+)
 from numba.core.typing.templates import builtin_registry as templates_registry
 from numba.core.typing.templates import signature
-from numba.extending import (intrinsic, lower_builtin, overload_classmethod,
-                             register_model, type_callable, typeof_impl)
+from numba.extending import intrinsic, overload_classmethod, register_model, typeof_impl
 from numba.np import numpy_support
 from numba.np.arrayobj import _array_copy
 
-from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
+from numba_dppy.dppy_array_type import DPPYArray
+
+# from numba_dppy.dppy_array_type import DPPYArrayModel
 
 from . import target as dppy_target
+
+import numba_dppy._usm_shared_allocator_ext
 
 debug = config.DEBUG
 
@@ -60,11 +58,6 @@ def dprint(*args):
         print(*args)
         sys.stdout.flush()
 
-
-import dpctl
-from dpctl.memory import MemoryUSMShared
-
-import numba_dppy._usm_shared_allocator_ext
 
 # Register the helper function in dppl_rt so that we can insert calls to them via llvmlite.
 for py_name, c_address in numba_dppy._usm_shared_allocator_ext.c_helpers.items():

--- a/numba_dppy/numpy_usm_shared.py
+++ b/numba_dppy/numpy_usm_shared.py
@@ -12,51 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-from inspect import getmembers, isfunction, isclass, isbuiltin
-from numbers import Number
-import numba
-from types import FunctionType as ftype, BuiltinFunctionType as bftype
-from numba import types
-from numba.extending import (
-    typeof_impl,
-    register_model,
-    type_callable,
-    lower_builtin,
-    intrinsic,
-    overload_classmethod,
-)
-from numba.core.datamodel.registry import register_default as register_model_default
-from numba.np import numpy_support
-from numba.core.pythonapi import box
-from llvmlite import ir
-import llvmlite.llvmpy.core as lc
-import llvmlite.binding as llb
-from numba.core import types, cgutils, config, typing
 import builtins
+import functools
+import importlib
+import inspect
 import sys
 from ctypes.util import find_library
-from numba.core.typing.templates import builtin_registry as templates_registry
-from numba.core.typing.npydecl import registry as typing_registry
-from numba.core.imputils import builtin_registry as lower_registry
-import importlib
-import functools
-import inspect
-from numba.core.typing.templates import (
-    CallableTemplate,
-    AttributeTemplate,
-    signature,
-    bound_function,
-)
-from numba.core.typing.arraydecl import normalize_shape
-from numba.np.arrayobj import _array_copy
+from inspect import getmembers, isbuiltin, isclass, isfunction
+from numbers import Number
+from types import BuiltinFunctionType as bftype
+from types import FunctionType as ftype
 
 import dpctl.tensor.numpy_usm_shared as nus
-from dpctl.tensor.numpy_usm_shared import ndarray, functions_list, class_list
-from . import target as dppy_target
+import llvmlite.binding as llb
+import llvmlite.llvmpy.core as lc
+import numba
+import numpy as np
+from dpctl.tensor.numpy_usm_shared import class_list, functions_list, ndarray
+from llvmlite import ir
+from numba import types
+from numba.core import cgutils, config, types, typing
+from numba.core.datamodel.registry import \
+    register_default as register_model_default
+from numba.core.imputils import builtin_registry as lower_registry
+from numba.core.overload_glue import _overload_glue
+from numba.core.pythonapi import box
+from numba.core.typing.arraydecl import normalize_shape
+from numba.core.typing.npydecl import registry as typing_registry
+from numba.core.typing.templates import (AttributeTemplate, CallableTemplate,
+                                         bound_function)
+from numba.core.typing.templates import builtin_registry as templates_registry
+from numba.core.typing.templates import signature
+from numba.extending import (intrinsic, lower_builtin, overload_classmethod,
+                             register_model, type_callable, typeof_impl)
+from numba.np import numpy_support
+from numba.np.arrayobj import _array_copy
+
 from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
 
-from numba.core.overload_glue import _overload_glue
+from . import target as dppy_target
 
 debug = config.DEBUG
 
@@ -69,6 +63,7 @@ def dprint(*args):
 
 import dpctl
 from dpctl.memory import MemoryUSMShared
+
 import numba_dppy._usm_shared_allocator_ext
 
 # Register the helper function in dppl_rt so that we can insert calls to them via llvmlite.

--- a/numba_dppy/ocl/mathdecl.py
+++ b/numba_dppy/ocl/mathdecl.py
@@ -14,7 +14,7 @@
 
 import math
 
-from numba.core import types, utils
+from numba.core import types
 from numba.core.typing.templates import (AttributeTemplate, ConcreteTemplate,
                                          Registry, signature)
 

--- a/numba_dppy/ocl/mathdecl.py
+++ b/numba_dppy/ocl/mathdecl.py
@@ -15,8 +15,12 @@
 import math
 
 from numba.core import types
-from numba.core.typing.templates import (AttributeTemplate, ConcreteTemplate,
-                                         Registry, signature)
+from numba.core.typing.templates import (
+    AttributeTemplate,
+    ConcreteTemplate,
+    Registry,
+    signature,
+)
 
 registry = Registry()
 builtin_attr = registry.register_attr

--- a/numba_dppy/ocl/mathdecl.py
+++ b/numba_dppy/ocl/mathdecl.py
@@ -13,13 +13,10 @@
 # limitations under the License.
 
 import math
+
 from numba.core import types, utils
-from numba.core.typing.templates import (
-    AttributeTemplate,
-    ConcreteTemplate,
-    signature,
-    Registry,
-)
+from numba.core.typing.templates import (AttributeTemplate, ConcreteTemplate,
+                                         Registry, signature)
 
 registry = Registry()
 builtin_attr = registry.register_attr

--- a/numba_dppy/ocl/mathimpl.py
+++ b/numba_dppy/ocl/mathimpl.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import math
-import numpy
 import warnings
 
-from numba.core.imputils import Registry
+import numpy
 from numba.core import types
+from numba.core.imputils import Registry
 from numba.core.itanium_mangler import mangle
+
 from .oclimpl import _declare_function
 
 registry = Registry()

--- a/numba_dppy/ocl/ocldecl.py
+++ b/numba_dppy/ocl/ocldecl.py
@@ -14,9 +14,14 @@
 
 from numba import types
 from numba.core.typing.npydecl import parse_dtype, parse_shape
-from numba.core.typing.templates import (AbstractTemplate, AttributeTemplate,
-                                         CallableTemplate, ConcreteTemplate,
-                                         Registry, signature)
+from numba.core.typing.templates import (
+    AbstractTemplate,
+    AttributeTemplate,
+    CallableTemplate,
+    ConcreteTemplate,
+    Registry,
+    signature,
+)
 
 import numba_dppy as dppy
 from numba_dppy.dppy_array_type import DPPYArray

--- a/numba_dppy/ocl/ocldecl.py
+++ b/numba_dppy/ocl/ocldecl.py
@@ -14,14 +14,10 @@
 
 from numba import types
 from numba.core.typing.npydecl import parse_dtype, parse_shape
-from numba.core.typing.templates import (
-    AttributeTemplate,
-    ConcreteTemplate,
-    AbstractTemplate,
-    CallableTemplate,
-    signature,
-    Registry,
-)
+from numba.core.typing.templates import (AbstractTemplate, AttributeTemplate,
+                                         CallableTemplate, ConcreteTemplate,
+                                         Registry, signature)
+
 import numba_dppy as dppy
 from numba_dppy.dppy_array_type import DPPYArray
 from numba_dppy.utils import address_space

--- a/numba_dppy/ocl/oclimpl.py
+++ b/numba_dppy/ocl/oclimpl.py
@@ -25,8 +25,7 @@ from numba.core.imputils import Registry
 from numba.core.itanium_mangler import mangle, mangle_c, mangle_type
 from numba.core.typing.npydecl import parse_dtype
 
-from numba_dppy import config
-from numba_dppy import target
+from numba_dppy import config, target
 from numba_dppy.codegen import SPIR_DATA_LAYOUT
 from numba_dppy.dppy_array_type import DPPYArray
 from numba_dppy.ocl.atomics import atomic_helper
@@ -282,7 +281,8 @@ def native_atomic_add(context, builder, sig, args):
         context.get_value_type(sig.args[2]),
     ]
 
-    from numba_dppy import extended_numba_itanium_mangler as ext_itanium_mangler
+    from numba_dppy import \
+        extended_numba_itanium_mangler as ext_itanium_mangler
 
     numba_ptr_ty = types.CPointer(dtype, addrspace=ptr_type.addrspace)
     mangled_fn_name = ext_itanium_mangler.mangle(

--- a/numba_dppy/ocl/oclimpl.py
+++ b/numba_dppy/ocl/oclimpl.py
@@ -212,7 +212,7 @@ def insert_and_call_atomic_fn(
     else:
         name = name + "_global"
 
-    assert ll_p != None
+    assert ll_p is not None
     assert name != ""
     ll_p.addrspace = address_space.GENERIC
 

--- a/numba_dppy/ocl/oclimpl.py
+++ b/numba_dppy/ocl/oclimpl.py
@@ -281,8 +281,7 @@ def native_atomic_add(context, builder, sig, args):
         context.get_value_type(sig.args[2]),
     ]
 
-    from numba_dppy import \
-        extended_numba_itanium_mangler as ext_itanium_mangler
+    from numba_dppy import extended_numba_itanium_mangler as ext_itanium_mangler
 
     numba_ptr_ty = types.CPointer(dtype, addrspace=ptr_type.addrspace)
     mangled_fn_name = ext_itanium_mangler.mangle(

--- a/numba_dppy/ocl/stubs.py
+++ b/numba_dppy/ocl/stubs.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba
-import numpy as np
-from numba.core import ir, types, typing
-from numba.np import numpy_support
-
 _stub_error = NotImplementedError("This is a stub.")
 
 # mem fence

--- a/numba_dppy/ocl/stubs.py
+++ b/numba_dppy/ocl/stubs.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba.core import types, ir, typing
-
-import numpy as np
 import numba
+import numpy as np
+from numba.core import ir, types, typing
 from numba.np import numpy_support
 
 _stub_error = NotImplementedError("This is a stub.")

--- a/numba_dppy/printimpl.py
+++ b/numba_dppy/printimpl.py
@@ -50,7 +50,7 @@ def int_print_impl(ty, context, builder, val):
     else:
         rawfmt = "%lld"
         dsttype = types.int64
-    fmt = context.insert_const_string(builder.module, rawfmt)
+    fmt = context.insert_const_string(builder.module, rawfmt)  # noqa
     lld = context.cast(builder, val, ty, dsttype)
     return rawfmt, [lld]
 

--- a/numba_dppy/printimpl.py
+++ b/numba_dppy/printimpl.py
@@ -15,8 +15,7 @@
 from functools import singledispatch
 
 import llvmlite.llvmpy.core as lc
-
-from numba.core import types, typing, cgutils
+from numba.core import cgutils, types, typing
 from numba.core.imputils import Registry
 
 from numba_dppy.utils import address_space

--- a/numba_dppy/rename_numpy_functions_pass.py
+++ b/numba_dppy/rename_numpy_functions_pass.py
@@ -14,8 +14,12 @@
 
 from numba.core import ir, types
 from numba.core.compiler_machinery import FunctionPass, register_pass
-from numba.core.ir_utils import (find_topo_order, mk_unique_var, remove_dead,
-                                 simplify_CFG)
+from numba.core.ir_utils import (
+    find_topo_order,
+    mk_unique_var,
+    remove_dead,
+    simplify_CFG,
+)
 
 import numba_dppy
 

--- a/numba_dppy/rename_numpy_functions_pass.py
+++ b/numba_dppy/rename_numpy_functions_pass.py
@@ -12,17 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba.core import ir
+from numba.core import ir, types
 from numba.core.compiler_machinery import FunctionPass, register_pass
-from numba.core.ir_utils import (
-    find_topo_order,
-    mk_unique_var,
-    remove_dead,
-    simplify_CFG,
-)
-import numba_dppy
-from numba.core import types
+from numba.core.ir_utils import (find_topo_order, mk_unique_var, remove_dead,
+                                 simplify_CFG)
 
+import numba_dppy
 
 rewrite_function_name_map = {
     # numpy
@@ -204,8 +199,6 @@ class DPPYRewriteOverloadedNumPyFunctions(FunctionPass):
     def __init__(self):
         FunctionPass.__init__(self)
 
-        import numba_dppy.dpnp_glue.dpnpdecl
-        import numba_dppy.dpnp_glue.dpnpimpl
         import numba_dppy.dpnp_glue.dpnp_array_creations_impl
         import numba_dppy.dpnp_glue.dpnp_array_ops_impl
         import numba_dppy.dpnp_glue.dpnp_indexing
@@ -216,6 +209,8 @@ class DPPYRewriteOverloadedNumPyFunctions(FunctionPass):
         import numba_dppy.dpnp_glue.dpnp_sort_search_countimpl
         import numba_dppy.dpnp_glue.dpnp_statisticsimpl
         import numba_dppy.dpnp_glue.dpnp_transcendentalsimpl
+        import numba_dppy.dpnp_glue.dpnpdecl
+        import numba_dppy.dpnp_glue.dpnpimpl
 
     def run_pass(self, state):
         rewrite_function_name_pass = RewriteNumPyOverloadedFunctions(

--- a/numba_dppy/retarget.py
+++ b/numba_dppy/retarget.py
@@ -19,6 +19,7 @@ from numba import njit
 from numba._dispatcher import set_use_tls_target_stack
 from numba.core.dispatcher import TargetConfig
 from numba.core.retarget import BasicRetarget
+
 from numba_dppy.target import DPPY_TARGET_NAME
 
 

--- a/numba_dppy/retarget.py
+++ b/numba_dppy/retarget.py
@@ -16,7 +16,6 @@ from contextlib import contextmanager
 
 import dpctl
 from numba import njit
-from numba._dispatcher import set_use_tls_target_stack
 from numba.core.dispatcher import TargetConfig
 from numba.core.retarget import BasicRetarget
 

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -15,9 +15,8 @@
 """A wrapper to connect to the SPIR-V binaries (Tools, Translator)."""
 
 import os
-import sys
 import tempfile
-from subprocess import CalledProcessError, call, check_call
+from subprocess import CalledProcessError, check_call
 
 from numba_dppy import config
 from numba_dppy.target import LINK_ATOMIC, LLVM_SPIRV_ARGS

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -14,10 +14,10 @@
 
 """A wrapper to connect to the SPIR-V binaries (Tools, Translator)."""
 
-import sys
 import os
-from subprocess import check_call, CalledProcessError, call
+import sys
 import tempfile
+from subprocess import CalledProcessError, call, check_call
 
 from numba_dppy import config
 from numba_dppy.target import LINK_ATOMIC, LLVM_SPIRV_ARGS

--- a/numba_dppy/target.py
+++ b/numba_dppy/target.py
@@ -13,24 +13,24 @@
 # limitations under the License.
 
 import re
+
 import numpy as np
-
-from llvmlite.llvmpy import core as lc
-from llvmlite import ir as llvmir
 from llvmlite import binding as ll
-
-from numba.core import typing, types, utils, cgutils
+from llvmlite import ir as llvmir
+from llvmlite.llvmpy import core as lc
 from numba import typeof
-from numba.core.utils import cached_property
-from numba.core import datamodel
+from numba.core import cgutils, datamodel, types, typing, utils
 from numba.core.base import BaseContext
-from numba.core.registry import cpu_target
 from numba.core.callconv import MinimalCallConv
-from . import codegen
-from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
+from numba.core.registry import cpu_target
 from numba.core.target_extension import GPU, target_registry
-from numba_dppy.utils import npytypes_array_to_dppy_array, address_space, calling_conv
+from numba.core.utils import cached_property
 
+from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
+from numba_dppy.utils import (address_space, calling_conv,
+                              npytypes_array_to_dppy_array)
+
+from . import codegen
 
 CC_SPIR_KERNEL = "spir_kernel"
 CC_SPIR_FUNC = "spir_func"
@@ -78,8 +78,9 @@ class DPPYTypingContext(typing.BaseContext):
 
     def load_additional_registries(self):
         """Register the OpenCL API and math and other functions."""
-        from .ocl import ocldecl, mathdecl
         from numba.core.typing import cmathdecl, npydecl
+
+        from .ocl import mathdecl, ocldecl
 
         self.install_registry(ocldecl.registry)
         self.install_registry(mathdecl.registry)
@@ -275,8 +276,9 @@ class DPPYTargetContext(BaseContext):
         self.data_model_manager = _init_data_model_manager()
         self.extra_compile_options = dict()
 
-        from numba.np.ufunc_db import _lazy_init_db
         import copy
+
+        from numba.np.ufunc_db import _lazy_init_db
 
         _lazy_init_db()
         from numba.np.ufunc_db import _ufunc_db as ufunc_db
@@ -335,10 +337,11 @@ class DPPYTargetContext(BaseContext):
         been registered into the target context.
 
         """
-        from .ocl import oclimpl, mathimpl
+        from numba.cpython import numbers, slicing, tupleobj
         from numba.np import npyimpl
+
         from . import printimpl
-        from numba.cpython import numbers, tupleobj, slicing
+        from .ocl import mathimpl, oclimpl
 
         self.insert_func_defn(oclimpl.registry.functions)
         self.insert_func_defn(mathimpl.registry.functions)

--- a/numba_dppy/target.py
+++ b/numba_dppy/target.py
@@ -27,8 +27,7 @@ from numba.core.target_extension import GPU, target_registry
 from numba.core.utils import cached_property
 
 from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
-from numba_dppy.utils import (address_space, calling_conv,
-                              npytypes_array_to_dppy_array)
+from numba_dppy.utils import address_space, calling_conv, npytypes_array_to_dppy_array
 
 from . import codegen
 

--- a/numba_dppy/target.py
+++ b/numba_dppy/target.py
@@ -337,7 +337,6 @@ class DPPYTargetContext(BaseContext):
         been registered into the target context.
 
         """
-        from numba.cpython import numbers, slicing, tupleobj
         from numba.np import npyimpl
 
         from . import printimpl

--- a/numba_dppy/tests/_helper.py
+++ b/numba_dppy/tests/_helper.py
@@ -13,15 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import contextlib
-
+import sys
 import unittest
+
 import dpctl
-from numba.tests.support import (
-    captured_stdout,
-    redirect_c_stdout,
-)
+from numba.tests.support import captured_stdout, redirect_c_stdout
 
 import numba_dppy
 from numba_dppy import config
@@ -114,7 +111,7 @@ def captured_dppy_stdout():
     # Prevent accidentally capturing previously output text
     sys.stdout.flush()
 
-    import numba_dppy, numba_dppy as dppy
+    import numba_dppy as dppy
 
     with redirect_c_stdout() as stream:
         yield DPPYTextCapture(stream)

--- a/numba_dppy/tests/_helper.py
+++ b/numba_dppy/tests/_helper.py
@@ -14,13 +14,11 @@
 # limitations under the License.
 
 import contextlib
-import sys
 import unittest
 
 import dpctl
-from numba.tests.support import captured_stdout, redirect_c_stdout
+from numba.tests.support import captured_stdout
 
-import numba_dppy
 from numba_dppy import config
 
 
@@ -46,7 +44,7 @@ def has_sycl_platforms():
     """
     platforms = dpctl.get_platforms()
     for p in platforms:
-        if not p.backend is dpctl.backend_type.host:
+        if p.backend is not dpctl.backend_type.host:
             return True
     return False
 
@@ -101,20 +99,6 @@ def override_config(name, value, config=config):
         yield
     finally:
         setattr(config, name, old_value)
-
-
-@contextlib.contextmanager
-def captured_dppy_stdout():
-    """
-    Return a minimal stream-like object capturing the text output of dppy
-    """
-    # Prevent accidentally capturing previously output text
-    sys.stdout.flush()
-
-    import numba_dppy as dppy
-
-    with redirect_c_stdout() as stream:
-        yield DPPYTextCapture(stream)
 
 
 def _id(obj):

--- a/numba_dppy/tests/conftest.py
+++ b/numba_dppy/tests/conftest.py
@@ -15,7 +15,6 @@
 
 import pytest
 
-
 offload_devices = [
     "opencl:gpu:0",
     "level_zero:gpu:0",

--- a/numba_dppy/tests/integration/test_dpnp_interop.py
+++ b/numba_dppy/tests/integration/test_dpnp_interop.py
@@ -15,8 +15,9 @@
 import dpctl
 import dpctl.tensor as dpt
 import numpy as np
-from numba import njit
 import pytest
+from numba import njit
+
 import numba_dppy as dppy
 from numba_dppy.tests._helper import ensure_dpnp, skip_test
 

--- a/numba_dppy/tests/integration/test_dpnp_interop.py
+++ b/numba_dppy/tests/integration/test_dpnp_interop.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dpctl
-import dpctl.tensor as dpt
 import numpy as np
 import pytest
-from numba import njit
 
 import numba_dppy as dppy
 from numba_dppy.tests._helper import ensure_dpnp, skip_test

--- a/numba_dppy/tests/integration/test_usm_ndarray_interop.py
+++ b/numba_dppy/tests/integration/test_usm_ndarray_interop.py
@@ -15,12 +15,11 @@
 import dpctl
 import dpctl.tensor as dpt
 import numpy as np
-from numba import njit
 import pytest
+from numba import njit
+
 import numba_dppy as dppy
 from numba_dppy.tests._helper import skip_test
-
-import dpctl.tensor as dpt
 
 list_of_dtype = [
     np.int32,

--- a/numba_dppy/tests/kernel_tests/test_arg_accessor.py
+++ b/numba_dppy/tests/kernel_tests/test_arg_accessor.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
-import pytest
 import dpctl
+import numpy as np
+import pytest
+
+import numba_dppy as dppy
 from numba_dppy.tests._helper import skip_test
 
 

--- a/numba_dppy/tests/kernel_tests/test_arg_types.py
+++ b/numba_dppy/tests/kernel_tests/test_arg_types.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
-import pytest
 import dpctl
+import numpy as np
+import pytest
+
+import numba_dppy as dppy
 from numba_dppy.tests._helper import skip_test
 
 global_size = 1054

--- a/numba_dppy/tests/kernel_tests/test_atomic_op.py
+++ b/numba_dppy/tests/kernel_tests/test_atomic_op.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-from numba_dppy.tests._helper import skip_test
-
 import os
+
+import dpctl
+import numpy as np
+import pytest
+
 import numba_dppy as dppy
 from numba_dppy import config
-import pytest
-import dpctl
-
+from numba_dppy.tests._helper import skip_test
 
 global_size = 100
 N = global_size

--- a/numba_dppy/tests/kernel_tests/test_atomic_op.py
+++ b/numba_dppy/tests/kernel_tests/test_atomic_op.py
@@ -191,7 +191,7 @@ def addrspace(request):
 
 def test_atomic_fp_native(filter_str, return_list_of_op, fdtype, addrspace):
     LLVM_SPIRV_ROOT = os.environ.get("NUMBA_DPPY_LLVM_SPIRV_ROOT")
-    if LLVM_SPIRV_ROOT == "" or LLVM_SPIRV_ROOT == None:
+    if LLVM_SPIRV_ROOT == "" or LLVM_SPIRV_ROOT is None:
         pytest.skip("Please set envar NUMBA_DPPY_LLVM_SPIRV_ROOT to run this test")
 
     if atomic_skip_test(filter_str):

--- a/numba_dppy/tests/kernel_tests/test_barrier.py
+++ b/numba_dppy/tests/kernel_tests/test_barrier.py
@@ -14,13 +14,12 @@
 
 import platform
 
+import dpctl
 import numpy as np
 import pytest
-import dpctl
 
 import numba_dppy as dppy
 from numba_dppy.tests._helper import skip_test
-
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/kernel_tests/test_caching.py
+++ b/numba_dppy/tests/kernel_tests/test_caching.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
-import pytest
 import dpctl
+import numpy as np
+import pytest
+
+import numba_dppy as dppy
 from numba_dppy.tests._helper import skip_test
 
 list_of_filter_strs = [

--- a/numba_dppy/tests/kernel_tests/test_math_functions.py
+++ b/numba_dppy/tests/kernel_tests/test_math_functions.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import dpctl
-import numba_dppy as dppy
 import numpy as np
 import pytest
-import math
+
+import numba_dppy as dppy
 from numba_dppy.tests._helper import skip_test
 
 list_of_filter_strs = [

--- a/numba_dppy/tests/kernel_tests/test_print.py
+++ b/numba_dppy/tests/kernel_tests/test_print.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
-import pytest
 import dpctl
+import numpy as np
+import pytest
+
+import numba_dppy as dppy
 from numba_dppy.tests._helper import skip_test
 
 list_of_filter_strs = [

--- a/numba_dppy/tests/kernel_tests/test_return_type.py
+++ b/numba_dppy/tests/kernel_tests/test_return_type.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dpctl
 import numpy as np
 import pytest
-import dpctl
-from numba_dppy.tests._helper import skip_test
+
 import numba_dppy as dppy
+from numba_dppy.tests._helper import skip_test
 
 
 def f(a):

--- a/numba_dppy/tests/njit_tests/__init__.py
+++ b/numba_dppy/tests/njit_tests/__init__.py
@@ -16,5 +16,5 @@
 # limitations under the License.
 ################################################################################
 
-from . import *
 from .._helper import *
+from . import *

--- a/numba_dppy/tests/njit_tests/dpnp/dpnp_skip_test.py
+++ b/numba_dppy/tests/njit_tests/dpnp/dpnp_skip_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba_dppy.tests._helper import skip_test, ensure_dpnp
+from numba_dppy.tests._helper import ensure_dpnp, skip_test
 
 
 def dpnp_skip_test(device_type):

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_creation.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_creation.py
@@ -18,13 +18,14 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from numba_dppy.tests._helper import dpnp_debug
-from .dpnp_skip_test import dpnp_skip_test as skip_test
-from ._helper import wrapper_function, args_string
-import numba_dppy as dppy
+from numba import njit
 
+import numba_dppy as dppy
+from numba_dppy.tests._helper import dpnp_debug
+
+from ._helper import args_string, wrapper_function
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_ops.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_ops.py
@@ -18,13 +18,14 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from .dpnp_skip_test import dpnp_skip_test as skip_test
-from numba_dppy.tests._helper import is_gen12, dpnp_debug
-from ._helper import wrapper_function
-import numba_dppy as dppy
+from numba import njit
 
+import numba_dppy as dppy
+from numba_dppy.tests._helper import dpnp_debug, is_gen12
+
+from ._helper import wrapper_function
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_indexing.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_indexing.py
@@ -18,12 +18,13 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from numba_dppy.tests._helper import dpnp_debug
-from .dpnp_skip_test import dpnp_skip_test as skip_test
-import numba_dppy as dppy
+from numba import njit
 
+import numba_dppy as dppy
+from numba_dppy.tests._helper import dpnp_debug
+
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_linalg.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_linalg.py
@@ -18,12 +18,14 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from .dpnp_skip_test import dpnp_skip_test as skip_test
-from ._helper import wrapper_function, args_string
-from numba_dppy.tests._helper import dpnp_debug
+from numba import njit
+
 import numba_dppy as dppy
+from numba_dppy.tests._helper import dpnp_debug
+
+from ._helper import args_string, wrapper_function
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 
 # From https://github.com/IntelPython/dpnp/blob/0.4.0/tests/test_linalg.py#L8

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_logic.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_logic.py
@@ -18,12 +18,13 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
+from numba import njit
+
 import numba_dppy as dppy
 from numba_dppy.tests._helper import dpnp_debug
-from .dpnp_skip_test import dpnp_skip_test as skip_test
 
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_logic.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_logic.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-import dpctl
 import numpy as np
 import pytest
 from numba import njit

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_manipulation.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_manipulation.py
@@ -18,12 +18,13 @@
 
 import dpctl
 import numpy as np
-from numba import njit
-import numba_dppy as dppy
 import pytest
-from numba_dppy.tests._helper import dpnp_debug
-from .dpnp_skip_test import dpnp_skip_test as skip_test
+from numba import njit
 
+import numba_dppy as dppy
+from numba_dppy.tests._helper import dpnp_debug
+
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_rng.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_rng.py
@@ -92,9 +92,9 @@ def test_one_arg_fn(filter_str, one_arg_fn, unary_size, capfd):
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
 
-        if low != None:
+        if low is not None:
             assert np.all(actual >= low)
-        if high != None:
+        if high is not None:
             assert np.all(actual < high)
 
 
@@ -135,7 +135,7 @@ def test_two_arg_fn(filter_str, two_arg_fn, unary_size, capfd):
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
 
-        if low != None and high == None:
+        if low is not None and high is None:
             if np.isscalar(actual):
                 assert actual >= low
             else:
@@ -194,7 +194,7 @@ def test_three_arg_fn(filter_str, three_arg_fn, three_arg_size, capfd):
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
 
-        if low != None and high == None:
+        if low is not None and high is None:
             if second_arg:
                 low = first_arg
                 high = second_arg
@@ -204,7 +204,7 @@ def test_three_arg_fn(filter_str, three_arg_fn, three_arg_size, capfd):
                 high = first_arg
                 assert np.all(actual >= low)
                 assert np.all(actual <= high)
-        elif low != None and high != None:
+        elif low is not None and high is not None:
             if np.isscalar(actual):
                 assert actual >= low
                 assert actual <= high

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_rng.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_rng.py
@@ -18,13 +18,14 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from numba_dppy.tests._helper import dpnp_debug
-from .dpnp_skip_test import dpnp_skip_test as skip_test
-from ._helper import wrapper_function
-import numba_dppy as dppy
+from numba import njit
 
+import numba_dppy as dppy
+from numba_dppy.tests._helper import dpnp_debug
+
+from ._helper import wrapper_function
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 # dpnp throws -30 (CL_INVALID_VALUE) when invoked with multiple kinds of
 # devices at runtime, so testing for level_zero only

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_sort_search_count.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_sort_search_count.py
@@ -18,13 +18,14 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from .dpnp_skip_test import dpnp_skip_test as skip_test
-from ._helper import wrapper_function
-from numba_dppy.tests._helper import dpnp_debug
-import numba_dppy as dppy
+from numba import njit
 
+import numba_dppy as dppy
+from numba_dppy.tests._helper import dpnp_debug
+
+from ._helper import wrapper_function
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_statistics.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_statistics.py
@@ -18,13 +18,14 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from numba_dppy.tests._helper import dpnp_debug
-from .dpnp_skip_test import dpnp_skip_test as skip_test
-from ._helper import wrapper_function
-import numba_dppy as dppy
+from numba import njit
 
+import numba_dppy as dppy
+from numba_dppy.tests._helper import dpnp_debug
+
+from ._helper import wrapper_function
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_transcendentals.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_transcendentals.py
@@ -18,13 +18,14 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from .dpnp_skip_test import dpnp_skip_test as skip_test
-from numba_dppy.tests._helper import is_gen12, dpnp_debug
-from ._helper import wrapper_function
-import numba_dppy as dppy
+from numba import njit
 
+import numba_dppy as dppy
+from numba_dppy.tests._helper import dpnp_debug, is_gen12
+
+from ._helper import wrapper_function
+from .dpnp_skip_test import dpnp_skip_test as skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/test_numpy_bitwise_ops.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_bitwise_ops.py
@@ -18,10 +18,11 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from numba_dppy.tests._helper import skip_test, assert_auto_offloading
+from numba import njit
+
 import numba_dppy as dppy
+from numba_dppy.tests._helper import assert_auto_offloading, skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/test_numpy_logic_ops.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_logic_ops.py
@@ -18,10 +18,11 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from numba_dppy.tests._helper import skip_test, assert_auto_offloading
+from numba import njit
+
 import numba_dppy as dppy
+from numba_dppy.tests._helper import assert_auto_offloading, skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/test_numpy_transcedental_functions.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_transcedental_functions.py
@@ -18,10 +18,12 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from numba_dppy.tests._helper import skip_test, is_gen12, assert_auto_offloading
+from numba import njit
+
 import numba_dppy as dppy
+from numba_dppy.tests._helper import (assert_auto_offloading, is_gen12,
+                                      skip_test)
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/test_numpy_transcedental_functions.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_transcedental_functions.py
@@ -22,8 +22,7 @@ import pytest
 from numba import njit
 
 import numba_dppy as dppy
-from numba_dppy.tests._helper import (assert_auto_offloading, is_gen12,
-                                      skip_test)
+from numba_dppy.tests._helper import assert_auto_offloading, is_gen12, skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/test_numpy_trigonometric_functions.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_trigonometric_functions.py
@@ -18,10 +18,12 @@
 
 import dpctl
 import numpy as np
-from numba import njit
 import pytest
-from numba_dppy.tests._helper import skip_test, is_gen12, assert_auto_offloading
+from numba import njit
+
 import numba_dppy as dppy
+from numba_dppy.tests._helper import (assert_auto_offloading, is_gen12,
+                                      skip_test)
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/njit_tests/test_numpy_trigonometric_functions.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_trigonometric_functions.py
@@ -22,8 +22,7 @@ import pytest
 from numba import njit
 
 import numba_dppy as dppy
-from numba_dppy.tests._helper import (assert_auto_offloading, is_gen12,
-                                      skip_test)
+from numba_dppy.tests._helper import assert_auto_offloading, is_gen12, skip_test
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/test_array_utils.py
+++ b/numba_dppy/tests/test_array_utils.py
@@ -20,8 +20,7 @@ import numpy as np
 import pytest
 
 from numba_dppy.tests._helper import skip_test
-from numba_dppy.utils import (as_usm_obj, copy_to_numpy_from_usm_obj,
-                              has_usm_memory)
+from numba_dppy.utils import as_usm_obj, copy_to_numpy_from_usm_obj, has_usm_memory
 
 from . import _helper
 

--- a/numba_dppy/tests/test_array_utils.py
+++ b/numba_dppy/tests/test_array_utils.py
@@ -13,14 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dpctl
+import dpctl.memory as dpctl_mem
+import dpctl.tensor as dpt
 import numpy as np
 import pytest
-import dpctl
-import dpctl.tensor as dpt
-import dpctl.memory as dpctl_mem
-from . import _helper
-from numba_dppy.utils import has_usm_memory, as_usm_obj, copy_to_numpy_from_usm_obj
+
 from numba_dppy.tests._helper import skip_test
+from numba_dppy.utils import (as_usm_obj, copy_to_numpy_from_usm_obj,
+                              has_usm_memory)
+
+from . import _helper
 
 
 def test_has_usm_memory(offload_device):

--- a/numba_dppy/tests/test_black_scholes.py
+++ b/numba_dppy/tests/test_black_scholes.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import _helper
-import numpy as np
 import math
 import time
+import unittest
+
+import dpctl
+import numpy as np
 
 import numba_dppy as dppy
-import unittest
-import dpctl
 
+from . import _helper
 
 RISKFREE = 0.02
 VOLATILITY = 0.30

--- a/numba_dppy/tests/test_black_scholes.py
+++ b/numba_dppy/tests/test_black_scholes.py
@@ -16,7 +16,6 @@ import math
 import time
 import unittest
 
-import dpctl
 import numpy as np
 
 import numba_dppy as dppy

--- a/numba_dppy/tests/test_black_scholes.py
+++ b/numba_dppy/tests/test_black_scholes.py
@@ -144,7 +144,7 @@ class TestDPPYBlackScholes(unittest.TestCase):
                     VOLATILITY,
                 )
 
-        dt = time1 - time0
+        dt = time1 - time0  # noqa
 
         delta = np.abs(callResultNumpy - callResultNumbapro)
         L1norm = delta.sum() / np.abs(callResultNumpy).sum()

--- a/numba_dppy/tests/test_controllable_fallback.py
+++ b/numba_dppy/tests/test_controllable_fallback.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import _helper
-import numpy as np
 import unittest
 import warnings
 
-import numba
 import dpctl
+import numba
+import numpy as np
 
-from numba_dppy import config
 import numba_dppy
+from numba_dppy import config
+
+from . import _helper
 
 
 @unittest.skipUnless(_helper.has_gpu_queues(), "test only on GPU system")

--- a/numba_dppy/tests/test_debuginfo.py
+++ b/numba_dppy/tests/test_debuginfo.py
@@ -54,7 +54,7 @@ def test_debug_flag_generates_ir_with_debuginfo(debug_option):
 
     @dppy.kernel
     def foo(x):
-        x = 1
+        x = 1  # noqa
 
     sycl_queue = dpctl.get_current_queue()
     sig = (types.int32,)

--- a/numba_dppy/tests/test_debuginfo.py
+++ b/numba_dppy/tests/test_debuginfo.py
@@ -14,16 +14,15 @@
 # limitations under the License.
 
 import re
-import pytest
 
 import dpctl
+import pytest
 from numba.core import types
 
 import numba_dppy as dppy
 from numba_dppy import compiler
 from numba_dppy.tests._helper import override_config
 from numba_dppy.utils import npytypes_array_to_dppy_array
-
 
 debug_options = [True, False]
 

--- a/numba_dppy/tests/test_device_array_args.py
+++ b/numba_dppy/tests/test_device_array_args.py
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import _helper
-import numpy as np
-import numba_dppy as dppy
-import dpctl
 import unittest
+
+import dpctl
+import numpy as np
+
+import numba_dppy as dppy
+
+from . import _helper
 
 
 @dppy.kernel

--- a/numba_dppy/tests/test_dpctl_api.py
+++ b/numba_dppy/tests/test_dpctl_api.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import dpctl
+import pytest
+
 import numba_dppy as dppy
 from numba_dppy.tests._helper import skip_test
-
 
 list_of_filter_strs = [
     "opencl:gpu:0",

--- a/numba_dppy/tests/test_dpnp_functions.py
+++ b/numba_dppy/tests/test_dpnp_functions.py
@@ -13,17 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
+import dpctl
 import numpy as np
 from numba import njit
-import dpctl
-import unittest
+
 import numba_dppy as dppy
-from numba_dppy.tests._helper import (
-    ensure_dpnp,
-    assert_auto_offloading,
-    dpnp_debug,
-    has_gpu_queues,
-)
+from numba_dppy.tests._helper import (assert_auto_offloading, dpnp_debug,
+                                      ensure_dpnp, has_gpu_queues)
 
 
 @unittest.skipUnless(

--- a/numba_dppy/tests/test_dpnp_functions.py
+++ b/numba_dppy/tests/test_dpnp_functions.py
@@ -20,8 +20,12 @@ import numpy as np
 from numba import njit
 
 import numba_dppy as dppy
-from numba_dppy.tests._helper import (assert_auto_offloading, dpnp_debug,
-                                      ensure_dpnp, has_gpu_queues)
+from numba_dppy.tests._helper import (
+    assert_auto_offloading,
+    dpnp_debug,
+    ensure_dpnp,
+    has_gpu_queues,
+)
 
 
 @unittest.skipUnless(

--- a/numba_dppy/tests/test_dppy_fallback.py
+++ b/numba_dppy/tests/test_dppy_fallback.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-
-import numba
 import unittest
 import warnings
+
 import dpctl
+import numba
+import numpy as np
+
 import numba_dppy
+
 from . import _helper
 
 

--- a/numba_dppy/tests/test_dppy_func.py
+++ b/numba_dppy/tests/test_dppy_func.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
+import dpctl
 import numpy as np
 
 import numba_dppy as dppy
-import unittest
-import dpctl
+
 from . import _helper
 
 

--- a/numba_dppy/tests/test_itanium_mangler_extension.py
+++ b/numba_dppy/tests/test_itanium_mangler_extension.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba_dppy as dppy
 import pytest
-import numba_dppy.extended_numba_itanium_mangler as itanium_mangler
-from numba import int32, int64, uint32, uint64, float32, float64
+from numba import float32, float64, int32, int64, uint32, uint64
 from numba.core import types
+
+import numba_dppy as dppy
+import numba_dppy.extended_numba_itanium_mangler as itanium_mangler
 from numba_dppy.utils import address_space
 
 list_of_dtypes = [

--- a/numba_dppy/tests/test_itanium_mangler_extension.py
+++ b/numba_dppy/tests/test_itanium_mangler_extension.py
@@ -55,7 +55,7 @@ def test_mangling_arg_type(dtypes):
     assert got == expected
 
 
-def test_mangling_arg_type(dtypes, addrspaces):
+def test_mangling_arg_type_2(dtypes, addrspaces):
     dtype, expected_dtype_str = dtypes
     addrspace, expected_addrspace_str = addrspaces
     got = itanium_mangler.mangle_type(types.CPointer(dtype, addrspace=addrspace))

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
+import dpctl
+import dpctl.tensor.numpy_usm_shared as usmarray
 import numpy as np
+import pytest
 from numba import njit, prange
 from numba.core import compiler, cpu
 from numba.core.registry import cpu_target
-import dpctl
-import dpctl.tensor.numpy_usm_shared as usmarray
+
+import numba_dppy as dppy
 import numba_dppy.numpy_usm_shared as nus
 from numba_dppy.compiler import DPPYCompiler
-import numba_dppy as dppy
 
 
 def fn(a):

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -16,12 +16,11 @@ import dpctl
 import dpctl.tensor.numpy_usm_shared as usmarray
 import numpy as np
 import pytest
-from numba import njit, prange
+from numba import prange
 from numba.core import compiler, cpu
 from numba.core.registry import cpu_target
 
 import numba_dppy as dppy
-import numba_dppy.numpy_usm_shared as nus
 from numba_dppy.compiler import DPPYCompiler
 
 

--- a/numba_dppy/tests/test_offload_diagnostics.py
+++ b/numba_dppy/tests/test_offload_diagnostics.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 
 import unittest
+
+import dpctl
 import numpy as np
 from numba import njit, prange
 from numba.tests.support import captured_stdout
-import dpctl
 
 import numba_dppy as dppy
 from numba_dppy import config as dppy_config
+
 from . import _helper
 
 

--- a/numba_dppy/tests/test_parfor_lower_message.py
+++ b/numba_dppy/tests/test_parfor_lower_message.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
+import dpctl
 import numpy as np
 from numba import njit, prange
+from numba.tests.support import captured_stdout
+
 import numba_dppy as dppy
 from numba_dppy import config
-import unittest
-from numba.tests.support import captured_stdout
-import dpctl
+
 from . import _helper
 
 

--- a/numba_dppy/tests/test_prange.py
+++ b/numba_dppy/tests/test_prange.py
@@ -13,13 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import _helper
-import numpy as np
-import dpctl
-from numba import njit, prange
 import unittest
-from numba_dppy.tests._helper import assert_auto_offloading
+
+import dpctl
+import numpy as np
+from numba import njit, prange
+
 import numba_dppy as dppy
+from numba_dppy.tests._helper import assert_auto_offloading
+
+from . import _helper
 
 
 @unittest.skipUnless(_helper.has_gpu_queues(), "test only on GPU system")

--- a/numba_dppy/tests/test_rename_numpy_function_pass.py
+++ b/numba_dppy/tests/test_rename_numpy_function_pass.py
@@ -14,17 +14,17 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
+
 import numba
+import numpy as np
 from numba import typeof
+from numba.core import compiler, cpu, typing
+from numba.core.typed_passes import AnnotateTypes, NopythonTypeInference
+
 import numba_dppy
-from numba_dppy.tests._helper import ensure_dpnp
-from numba.core import compiler, typing, cpu
 from numba_dppy.rename_numpy_functions_pass import (
-    DPPYRewriteOverloadedNumPyFunctions,
-    DPPYRewriteNdarrayFunctions,
-)
-from numba.core.typed_passes import NopythonTypeInference, AnnotateTypes
+    DPPYRewriteNdarrayFunctions, DPPYRewriteOverloadedNumPyFunctions)
+from numba_dppy.tests._helper import ensure_dpnp
 
 
 class MyPipeline(object):

--- a/numba_dppy/tests/test_rename_numpy_function_pass.py
+++ b/numba_dppy/tests/test_rename_numpy_function_pass.py
@@ -23,7 +23,9 @@ from numba.core.typed_passes import AnnotateTypes, NopythonTypeInference
 
 import numba_dppy
 from numba_dppy.rename_numpy_functions_pass import (
-    DPPYRewriteNdarrayFunctions, DPPYRewriteOverloadedNumPyFunctions)
+    DPPYRewriteNdarrayFunctions,
+    DPPYRewriteOverloadedNumPyFunctions,
+)
 from numba_dppy.tests._helper import ensure_dpnp
 
 

--- a/numba_dppy/tests/test_strided_array.py
+++ b/numba_dppy/tests/test_strided_array.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import dpctl
 import numpy as np
 import pytest
 
 import numba_dppy
-from numba_dppy import config
 from numba_dppy.tests._helper import skip_test
 
 

--- a/numba_dppy/tests/test_strided_array.py
+++ b/numba_dppy/tests/test_strided_array.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import os
-import pytest
+
 import dpctl
+import numpy as np
+import pytest
 
 import numba_dppy
 from numba_dppy import config

--- a/numba_dppy/tests/test_sum_reduction.py
+++ b/numba_dppy/tests/test_sum_reduction.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-from . import _helper
 import math
-import numba_dppy as dppy
 import unittest
+
 import dpctl
+import numpy as np
+
+import numba_dppy as dppy
+
+from . import _helper
 
 
 @dppy.kernel

--- a/numba_dppy/tests/test_usm_ndarray_type.py
+++ b/numba_dppy/tests/test_usm_ndarray_type.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dpctl
 import dpctl.tensor as dpt
 import numpy as np
 import pytest
 from numba.misc.special import typeof
 
-import numba_dppy as dppy
 from numba_dppy.driver import USMNdArrayType
 from numba_dppy.tests._helper import skip_test
 

--- a/numba_dppy/tests/test_usm_ndarray_type.py
+++ b/numba_dppy/tests/test_usm_ndarray_type.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import numba_dppy as dppy
-import pytest
 import dpctl
 import dpctl.tensor as dpt
+import numpy as np
+import pytest
 from numba.misc.special import typeof
-from numba_dppy.tests._helper import skip_test
+
+import numba_dppy as dppy
 from numba_dppy.driver import USMNdArrayType
+from numba_dppy.tests._helper import skip_test
 
 list_of_dtypes = [
     np.int32,

--- a/numba_dppy/tests/test_usmarray.py
+++ b/numba_dppy/tests/test_usmarray.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numba
-import numpy
 import unittest
-import pytest
 
 import dpctl
 import dpctl.tensor.numpy_usm_shared as usmarray
+import numba
+import numpy
+import pytest
 
 
 @numba.njit()

--- a/numba_dppy/tests/test_usmarray.py
+++ b/numba_dppy/tests/test_usmarray.py
@@ -14,11 +14,9 @@
 
 import unittest
 
-import dpctl
 import dpctl.tensor.numpy_usm_shared as usmarray
 import numba
 import numpy
-import pytest
 
 
 @numba.njit()

--- a/numba_dppy/tests/test_vectorize.py
+++ b/numba_dppy/tests/test_vectorize.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-from numba import njit, vectorize, int32, float32, int64, float64
 import dpctl
+import numpy as np
+import pytest
+from numba import float32, float64, int32, int64, njit, vectorize
 
 import numba_dppy as dppy
 from numba_dppy.tests._helper import assert_auto_offloading
-import pytest
+
 from . import _helper
 
 list_of_filter_strs = [

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -17,7 +17,6 @@ import unittest
 import dpctl
 import numpy as np
 from numba import njit
-from numba.core import errors
 from numba.tests.support import captured_stdout
 
 import numba_dppy

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
+import dpctl
 import numpy as np
 from numba import njit
-import numba_dppy
-from numba_dppy import config
-import unittest
 from numba.core import errors
 from numba.tests.support import captured_stdout
-from . import _helper
-import dpctl
+
+import numba_dppy
 import numba_dppy as dppy
+from numba_dppy import config
+
+from . import _helper
 
 
 class TestWithDPPYContext(unittest.TestCase):

--- a/numba_dppy/utils/__init__.py
+++ b/numba_dppy/utils/__init__.py
@@ -16,15 +16,21 @@
 Various utility functions and classes to aid LLVM IR building.
 
 """
-from numba_dppy.utils.array_utils import (as_usm_obj,
-                                          copy_from_numpy_to_usm_obj,
-                                          copy_to_numpy_from_usm_obj,
-                                          has_usm_memory)
+from numba_dppy.utils.array_utils import (
+    as_usm_obj,
+    copy_from_numpy_to_usm_obj,
+    copy_to_numpy_from_usm_obj,
+    has_usm_memory,
+)
 from numba_dppy.utils.constants import address_space, calling_conv
-from numba_dppy.utils.llvm_codegen_helpers import (LLVMTypes, create_null_ptr,
-                                                   get_llvm_ptr_type,
-                                                   get_llvm_type, get_one,
-                                                   get_zero)
+from numba_dppy.utils.llvm_codegen_helpers import (
+    LLVMTypes,
+    create_null_ptr,
+    get_llvm_ptr_type,
+    get_llvm_type,
+    get_one,
+    get_zero,
+)
 from numba_dppy.utils.misc import assert_no_return
 from numba_dppy.utils.type_conversion_fns import npytypes_array_to_dppy_array
 

--- a/numba_dppy/utils/__init__.py
+++ b/numba_dppy/utils/__init__.py
@@ -16,24 +16,17 @@
 Various utility functions and classes to aid LLVM IR building.
 
 """
-from numba_dppy.utils.llvm_codegen_helpers import (
-    LLVMTypes,
-    get_llvm_type,
-    get_llvm_ptr_type,
-    create_null_ptr,
-    get_zero,
-    get_one,
-)
-
-from numba_dppy.utils.type_conversion_fns import npytypes_array_to_dppy_array
+from numba_dppy.utils.array_utils import (as_usm_obj,
+                                          copy_from_numpy_to_usm_obj,
+                                          copy_to_numpy_from_usm_obj,
+                                          has_usm_memory)
 from numba_dppy.utils.constants import address_space, calling_conv
-from numba_dppy.utils.array_utils import (
-    has_usm_memory,
-    as_usm_obj,
-    copy_from_numpy_to_usm_obj,
-    copy_to_numpy_from_usm_obj,
-)
+from numba_dppy.utils.llvm_codegen_helpers import (LLVMTypes, create_null_ptr,
+                                                   get_llvm_ptr_type,
+                                                   get_llvm_type, get_one,
+                                                   get_zero)
 from numba_dppy.utils.misc import assert_no_return
+from numba_dppy.utils.type_conversion_fns import npytypes_array_to_dppy_array
 
 __all__ = [
     "LLVMTypes",

--- a/numba_dppy/utils/array_utils.py
+++ b/numba_dppy/utils/array_utils.py
@@ -14,9 +14,9 @@
 
 """This module provides utilities to interact with USM memory."""
 
-import numpy as np
 import dpctl
 import dpctl.memory as dpctl_mem
+import numpy as np
 
 from numba_dppy import config
 

--- a/numba_dppy/utils/llvm_codegen_helpers.py
+++ b/numba_dppy/utils/llvm_codegen_helpers.py
@@ -14,7 +14,7 @@
 
 import llvmlite.ir as lir
 import llvmlite.llvmpy.core as lc
-from numba.core import types, cgutils
+from numba.core import cgutils, types
 
 
 class LLVMTypes:

--- a/numba_dppy/utils/type_conversion_fns.py
+++ b/numba_dppy/utils/type_conversion_fns.py
@@ -20,7 +20,9 @@ Currently the module supports the following converter functions:
 
 """
 from numba.core import types
+
 from numba_dppy import dppy_array_type
+
 from .constants import address_space
 
 __all__ = ["npytypes_array_to_dppy_array"]

--- a/numba_dppy/vectorizers.py
+++ b/numba_dppy/vectorizers.py
@@ -14,20 +14,17 @@
 
 """Provide @vectorize(target="dppy") support."""
 
+import warnings
+
+import dpctl
 import numpy as np
 from numba.np.ufunc import deviceufunc
-import dpctl
-import warnings
-import numba_dppy as dppy
-from numba_dppy.dppy_offload_dispatcher import DppyOffloadDispatcher
-from numba_dppy.utils import (
-    has_usm_memory,
-    as_usm_obj,
-    copy_from_numpy_to_usm_obj,
-    copy_to_numpy_from_usm_obj,
-)
 
+import numba_dppy as dppy
 from numba_dppy.descriptor import dppy_target
+from numba_dppy.dppy_offload_dispatcher import DppyOffloadDispatcher
+from numba_dppy.utils import (as_usm_obj, copy_from_numpy_to_usm_obj,
+                              copy_to_numpy_from_usm_obj, has_usm_memory)
 
 vectorizer_stager_source = """
 def __vectorized_{name}({args}, __out__):

--- a/numba_dppy/vectorizers.py
+++ b/numba_dppy/vectorizers.py
@@ -21,8 +21,7 @@ import numpy as np
 from numba.np.ufunc import deviceufunc
 
 import numba_dppy as dppy
-from numba_dppy.utils import (as_usm_obj, copy_to_numpy_from_usm_obj,
-                              has_usm_memory)
+from numba_dppy.utils import as_usm_obj, copy_to_numpy_from_usm_obj, has_usm_memory
 
 vectorizer_stager_source = """
 def __vectorized_{name}({args}, __out__):

--- a/numba_dppy/vectorizers.py
+++ b/numba_dppy/vectorizers.py
@@ -21,8 +21,8 @@ import numpy as np
 from numba.np.ufunc import deviceufunc
 
 import numba_dppy as dppy
-from numba_dppy.utils import (as_usm_obj,
-                              copy_to_numpy_from_usm_obj, has_usm_memory)
+from numba_dppy.utils import (as_usm_obj, copy_to_numpy_from_usm_obj,
+                              has_usm_memory)
 
 vectorizer_stager_source = """
 def __vectorized_{name}({args}, __out__):

--- a/numba_dppy/vectorizers.py
+++ b/numba_dppy/vectorizers.py
@@ -21,9 +21,7 @@ import numpy as np
 from numba.np.ufunc import deviceufunc
 
 import numba_dppy as dppy
-from numba_dppy.descriptor import dppy_target
-from numba_dppy.dppy_offload_dispatcher import DppyOffloadDispatcher
-from numba_dppy.utils import (as_usm_obj, copy_from_numpy_to_usm_obj,
+from numba_dppy.utils import (as_usm_obj,
                               copy_to_numpy_from_usm_obj, has_usm_memory)
 
 vectorizer_stager_source = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.black]
 exclude = 'versioneer.py'
+
+[tool.isort]
+profile = "black"

--- a/scripts/diag_env.sh
+++ b/scripts/diag_env.sh
@@ -3,7 +3,7 @@
 # See https://dgpu-docs.intel.com/installation-guides/ubuntu/ubuntu-focal.html
 
 check_package_installed() {
-  apt list --installed 2>/dev/null $1 | grep $1 || echo "$1 not installed"
+  apt list --installed 2>/dev/null "$1" | grep "$1" || echo "$1 not installed"
 }
 
 check_package_installed    intel-opencl-icd

--- a/scripts/run_debug_examples.sh
+++ b/scripts/run_debug_examples.sh
@@ -4,7 +4,7 @@ set -e
 
 check() {
   echo "Run $1 ..."
-  (cd numba_dppy/examples/debug && NUMBA_OPT=0 gdb-oneapi -q -command $1 python) | grep Done
+  (cd numba_dppy/examples/debug && NUMBA_OPT=0 gdb-oneapi -q -command "$1" python) | grep Done
 }
 
 run_checks() {

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -4,7 +4,7 @@ set -e
 
 check() {
   echo "Run $1 ..."
-  python $1 | grep $SYCL_DEVICE_FILTER
+  python "$1" | grep "$SYCL_DEVICE_FILTER"
   # python $1 | grep Done
 }
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import shlex
 import subprocess
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -13,17 +13,16 @@
 # limitations under the License.
 
 import os
-import sys
-import setuptools.command.install as orig_install
-import setuptools.command.develop as orig_develop
-import subprocess
 import shlex
-from setuptools import Extension, find_packages, setup
+import subprocess
+import sys
+
+import setuptools.command.develop as orig_develop
+import setuptools.command.install as orig_install
 from Cython.Build import cythonize
+from setuptools import Extension, find_packages, setup
 
 import versioneer
-import sys
-
 
 IS_WIN = False
 IS_LIN = False
@@ -45,7 +44,8 @@ def get_ext_modules():
     else:
         dpnp_present = True
 
-    import numba, dpctl
+    import dpctl
+    import numba
 
     dpctl_runtime_library_dirs = []
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -1595,6 +1595,7 @@ def get_cmdclass(cmdclass=None):
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
+
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{


### PR DESCRIPTION
A lot of improvements:
- `.gitattributes` for fixing Windows/Linux EOL - safely pass code from Windows to WSL
- Apply `flake8`, config and skips in `.flake8`, fixed a lot of warnings
- Add recommended VSCode extensions `.vscode/settings.json`
- Added `whitespace fixers`, `isort`, `flake8` and `shellcheck` in `pre-commit`
- Added buid and development environments for conda (`build-environment.yml` amd `environment.yml`)
- Fixed conda sctipts `build.sh` and `run_test.sh` using `shellcheck`
- Improved processing for `NUMBA_DPPY_LLVM_SPIRV_ROOT` in `run_test.sh`
- Configured `isort` to not conflict with `black`
- And more...