### PR TITLE
Use older compiler for backwards compatibility

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
-# Numba/llvmlite stack needs an older compiler for backwards compatability.
+# Numba/llvmlite stack needs an older compiler for backwards compatibility.
 c_compiler_version:         # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
   - 9                       # [linux and aarch64]

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,8 +1,6 @@
 # Numba/llvmlite stack needs an older compiler for backwards compatibility.
 c_compiler_version:         # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
-  - 9                       # [linux and aarch64]
 
 cxx_compiler_version:       # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
-  - 9                       # [linux and aarch64]

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+# Numba/llvmlite stack needs an older compiler for backwards compatability.
+c_compiler_version:         # [linux]
+  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 9                       # [linux and aarch64]
+
+cxx_compiler_version:       # [linux]
+  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 9                       # [linux and aarch64]

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 # Numba/llvmlite stack needs an older compiler for backwards compatibility.
 c_compiler_version:         # [linux]
-  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 7                       # [linux and x86_64]
 
 cxx_compiler_version:       # [linux]
-  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 7                       # [linux and x86_64]


### PR DESCRIPTION
Proposed here:
https://github.com/numba/numba-examples/pull/39