### PR TITLE
Update test and fix typo

### DIFF
--- a/docs/user_guides/kernel_programming_guide/atomic-operations.rst
+++ b/docs/user_guides/kernel_programming_guide/atomic-operations.rst
@@ -27,14 +27,14 @@ Numba-dppy supports generating native floating-point atomics.
 This feature is experimental. Users will need to provide
 the following environment variables to activate it.
 
-    NUMBA_DPPY_ACTIVATE_ATOMCIS_FP_NATIVE=1
+    NUMBA_DPPY_ACTIVATE_ATOMICS_FP_NATIVE=1
     NUMBA_DPPY_LLVM_SPIRV_ROOT=/path/to/dpcpp/provided/llvm_spirv
 
 Example command:
 
 .. code-block:: bash
 
-    NUMBA_DPPY_ACTIVATE_ATOMCIS_FP_NATIVE=1 \
+    NUMBA_DPPY_ACTIVATE_ATOMICS_FP_NATIVE=1 \
     NUMBA_DPPY_LLVM_SPIRV_ROOT=/path/to/dpcpp/provided/llvm_spirv \
     python program.py
 

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -101,7 +101,7 @@ FALLBACK_ON_CPU = _readenv("NUMBA_DPPY_FALLBACK_ON_CPU", int, 1)
 
 # Activate Native floating point atomcis support for supported devices.
 # Requires llvm-spirv supporting the FP atomics extensio
-NATIVE_FP_ATOMICS = _readenv("NUMBA_DPPY_ACTIVATE_ATOMCIS_FP_NATIVE", int, 0)
+NATIVE_FP_ATOMICS = _readenv("NUMBA_DPPY_ACTIVATE_ATOMICS_FP_NATIVE", int, 0)
 LLVM_SPIRV_ROOT = _readenv("NUMBA_DPPY_LLVM_SPIRV_ROOT", str, "")
 # Emit debug info
 DEBUG = _readenv("NUMBA_DPPY_DEBUG", int, config.DEBUG)

--- a/numba_dppy/examples/atomic_op.py
+++ b/numba_dppy/examples/atomic_op.py
@@ -26,11 +26,11 @@ def main():
 
     If we want to generate native floating point atomics for spported
     SYCL devices we need to set two environment variables:
-    NUMBA_DPPY_ACTIVATE_ATOMCIS_FP_NATIVE=1
+    NUMBA_DPPY_ACTIVATE_ATOMICS_FP_NATIVE=1
     NUMBA_DPPY_LLVM_SPIRV_ROOT=/path/to/dpcpp/provided/llvm_spirv
 
     To run this example:
-    NUMBA_DPPY_ACTIVATE_ATOMCIS_FP_NATIVE=1 NUMBA_DPPY_LLVM_SPIRV_ROOT=/path/to/dpcpp/provided/llvm_spirv python atomic_op.py
+    NUMBA_DPPY_ACTIVATE_ATOMICS_FP_NATIVE=1 NUMBA_DPPY_LLVM_SPIRV_ROOT=/path/to/dpcpp/provided/llvm_spirv python atomic_op.py
 
     Without these two environment variables Numba_dppy will use other
     implementation for floating point atomics.

--- a/numba_dppy/tests/kernel_tests/test_atomic_op.py
+++ b/numba_dppy/tests/kernel_tests/test_atomic_op.py
@@ -227,8 +227,7 @@ def test_atomic_fp_native(filter_str, return_list_of_op, fdtype, addrspace):
         else:
             assert "__spirv_AtomicFAddEXT" not in kern.assembly
 
-    config.NATIVE_FP_ATOMICS = NATIVE_FP_ATOMICS_old_val
-    config.LLVM_SPIRV_ROOT = LLVM_SPIRV_ROOT_old_val
+    config.NATIVE_FP_ATOMICS = 0
 
     # To bypass caching
     kernel = dppy.kernel(f)
@@ -237,3 +236,6 @@ def test_atomic_fp_native(filter_str, return_list_of_op, fdtype, addrspace):
             kernel._get_argtypes(a), sycl_queue
         )
         assert "__spirv_AtomicFAddEXT" not in kern.assembly
+
+    config.NATIVE_FP_ATOMICS = NATIVE_FP_ATOMICS_old_val
+    config.LLVM_SPIRV_ROOT = LLVM_SPIRV_ROOT_old_val


### PR DESCRIPTION
- Update typo in flag `NUMBA_DPPY_ACTIVATE_ATOMCIS_FP_NATIVE` -> `NUMBA_DPPY_ACTIVATE_ATOMICS_FP_NATIVE`.
- Update native atomic test.