### PR TITLE
Use `NUMBA_DPPY_DEBUG` for debugging GDB tests

### DIFF
--- a/numba_dppy/tests/test_debug_dppy_numba.py
+++ b/numba_dppy/tests/test_debug_dppy_numba.py
@@ -21,6 +21,7 @@ import sys
 import pytest
 
 import numba_dppy
+from numba_dppy import config
 
 pexpect = pytest.importorskip("pexpect")
 
@@ -44,7 +45,8 @@ class gdb:
         env["NUMBA_OPT"] = "0"
 
         self.child = pexpect.spawn("gdb-oneapi -q python", env=env, encoding="utf-8")
-        # self.child.logfile = sys.stdout
+        if config.DEBUG:
+            self.child.logfile = sys.stdout
 
     def setup_gdb(self):
         self.child.expect("(gdb)", timeout=5)


### PR DESCRIPTION
It allows to see log of GDB interactions via command:
```bash
NUMBA_DPPY_DEBUG=1 pytest -q -s -ra --disable-warnings --pyargs numba_dppy -vv -k test_debug_dppy_numba
```