### PR TITLE
Use dpnp 0.8*

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.54*|0.55*
         - dpctl 0.10*|0.11*
-        - dpnp >=0.8*  # [linux]
+        - dpnp 0.8*  # [linux]
         - wheel
     run:
         - python
@@ -28,7 +28,7 @@ requirements:
         - dpctl 0.10*|0.11*
         - spirv-tools
         - llvm-spirv 11.*
-        - dpnp >=0.8* # [linux]
+        - dpnp 0.8*  # [linux]
         - packaging
 
 test:


### PR DESCRIPTION
Current numba-dppy is not compatible w/ dpnp 0.9.
See #599.
For the future:
During building in internal CI the latest version of dpnp used. So the only way to restrict version of future packages now is to restrict it in the recipe. And enable support for the next dpnp version explicitly. Otherwise we will see red CI all time.