### PR TITLE
Improvements for automatically generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -17,7 +17,7 @@ changelog:
       labels:
         - removed-feature
     - title: Deprecated
-      label: 
+      labels:
         - deprecated-feature
     - title: Other Changes
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Added
+      labels:
+        - enhancement
+        - feature
+    - title: Changed
+      labels:
+        - feature-change
+    - title: Fixed
+      labels:
+        - bug
+    - title: Removed
+      labels:
+        - removed-feature
+    - title: Deprecated
+      label: 
+        - deprecated-feature
+    - title: Other Changes
+      labels:
+        - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.17.0] - 2021-11-xx
+
 ### Added
 * Use Python 3.9 [public CI] by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/574
 * Use `NUMBA_DPPY_DEBUG` for debugging GDB tests by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/578

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.0] - 2021-11-xx
 
 ### Added
+
 * Use Python 3.9 [public CI] by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/574
 * Use `NUMBA_DPPY_DEBUG` for debugging GDB tests by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/578
 * Preliminary support Numba 0.55 (master branch) by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/583
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update to dpnp 0.9 by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/599
 * Improve the documenatation landing page by @diptorupd in https://github.com/IntelPython/numba-dppy/pull/601
 * Clean up README by @diptorupd in https://github.com/IntelPython/numba-dppy/pull/604
+
 ### Fixed
 * Restrict dpctl to 0.10.* for release 0.16 by @1e-to in https://github.com/IntelPython/numba-dppy/pull/590
 * Fix upload from release branch by @1e-to in https://github.com/IntelPython/numba-dppy/pull/596

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.0] - 2021-11-xx
 
 ### Added
-
 * Use Python 3.9 [public CI] by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/574
+* Use `NUMBA_DPPY_DEBUG` for debugging GDB tests by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/578
 * Preliminary support Numba 0.55 (master branch) by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/583
 * Workflow for manually running tests using Numba PRs by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/586
 * Add public CI trigger on tags by @1e-to in https://github.com/IntelPython/numba-dppy/pull/589
@@ -17,16 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update to dpnp 0.9 by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/599
 * Improve the documenatation landing page by @diptorupd in https://github.com/IntelPython/numba-dppy/pull/601
 * Clean up README by @diptorupd in https://github.com/IntelPython/numba-dppy/pull/604
-
 ### Fixed
-
 * Restrict dpctl to 0.10.* for release 0.16 by @1e-to in https://github.com/IntelPython/numba-dppy/pull/590
 * Fix upload from release branch by @1e-to in https://github.com/IntelPython/numba-dppy/pull/596
 * Unskip tests passing with dpnp 0.9.0rc1 by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/606
-
-### Other Changes
-
-* Use `NUMBA_DPPY_DEBUG` for debugging GDB tests by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/578
 
 ## [0.16.1] - 2021-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.17.0] - 2021-11-xx
-
 ### Added
 
 * Use Python 3.9 [public CI] by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/574

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.17.0] - 2021-11-xx
 ### Added
-
 * Use Python 3.9 [public CI] by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/574
 * Use `NUMBA_DPPY_DEBUG` for debugging GDB tests by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/578
 * Preliminary support Numba 0.55 (master branch) by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/583

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.0] - 2021-10-xx
+## [0.17.0] - 2021-11-xx
 
 ### Added
 
-* Update to dpnp 0.9 (#599, #606)
-* Update to dpctl 0.11 (#595)
-* Clean up README. (#604)
-* Improve the documenatation landing page. (#601)
-* Upload packages for release* branches (#593, #596)
-* Manual run tests w/ Numba PR (#586)
-* Preliminary support Numba 0.55 (master branch) (#583)
-* Use Python 3.9 in public CI (#574)
-* Use NUMBA_DPPY_DEBUG for debugging GDB tests (#578)
+* Use Python 3.9 [public CI] by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/574
+* Preliminary support Numba 0.55 (master branch) by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/583
+* Workflow for manually running tests using Numba PRs by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/586
+* Add public CI trigger on tags by @1e-to in https://github.com/IntelPython/numba-dppy/pull/589
+* Upload packages for `release*` branches by @1e-to in https://github.com/IntelPython/numba-dppy/pull/593
+* Update to dpctl 0.11 by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/595
+* Update to dpnp 0.9 by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/599
+* Improve the documenatation landing page by @diptorupd in https://github.com/IntelPython/numba-dppy/pull/601
+* Clean up README by @diptorupd in https://github.com/IntelPython/numba-dppy/pull/604
+
+### Fixed
+
+* Restrict dpctl to 0.10.* for release 0.16 by @1e-to in https://github.com/IntelPython/numba-dppy/pull/590
+* Fix upload from release branch by @1e-to in https://github.com/IntelPython/numba-dppy/pull/596
+* Unskip tests passing with dpnp 0.9.0rc1 by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/606
+
+### Other Changes
+
+* Use `NUMBA_DPPY_DEBUG` for debugging GDB tests by @PokhodenkoSA in https://github.com/IntelPython/numba-dppy/pull/578
 
 ## [0.16.1] - 2021-10-20
 


### PR DESCRIPTION
Added `.github/release.yml` file according to this documentation
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

Also, assigned labels to PRs for generating better release notes.
Updated CHANGELOG.md with example of generated release notes.

Target to `release0.17` branch.