### PR TITLE
Use llvm-spirv from bin-llvm during build

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -2,6 +2,10 @@
 
 set -euxo pipefail
 
+# new llvm-spirv location
+# starting from dpcpp_impl_linux-64=2022.0.0=intel_3610
+export PATH=$CONDA_PREFIX/bin-llvm:$PATH
+
 ${PYTHON} setup.py install --single-version-externally-managed --record=record.txt
 
 # Build wheel package


### PR DESCRIPTION
DPC++ compiler package has new `llvm-spirv` location - `bin-llvm`.