### PR TITLE
Enable offloading for `numba.njit` in `dpctl.device_context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+## [0.17.3] - 2021-11-xx
+
+### Fixed
+* Enable offloading for `numba.njit` in `dpctl.deveice_context` (#630)
+
 ## [0.17.2] - 2021-11-15
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.17.2] - 2021-11-15
 
-### Changes
+### Changed
 * Use llvm-spirv from bin-llvm during build for Linux and Windows (#626, #627)
 
 ## [0.17.1] - 2021-11-10
 
-### Changes
+### Changed
 * Update clang to icx (#622)
 
 ## [0.17.0] - 2021-11-03

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ def div_kernel(dst, src, m):
     dst[i] = src[i] // m
 
 import dpctl
-with numba_dppy.offload_to_sycl_device(dpctl.SyclQueue()):
+with dpctl.device_context(dpctl.SyclQueue()):
     X = np.arange(10)
     Y = np.arange(10)
     div_kernel[10, numba_dppy.DEFAULT_LOCAL_SIZE](Y, X, 5)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,13 +19,13 @@ requirements:
         - setuptools
         - cython
         - numba 0.54*|0.55*
-        - dpctl 0.10*|0.11*
+        - dpctl 0.11*
         - dpnp 0.8*|0.9*           # [linux]
         - wheel
     run:
         - python
         - numba 0.54*|0.55*
-        - dpctl 0.10*|0.11*
+        - dpctl 0.11*
         - spirv-tools
         - llvm-spirv 11.*
         - dpnp 0.8*|0.9*           # [linux]

--- a/numba_dppy/__init__.py
+++ b/numba_dppy/__init__.py
@@ -518,7 +518,7 @@ Supported NumPy Functions:
 import numba.testing
 
 from numba_dppy.interop import asarray
-from numba_dppy.retarget import offload_to_sycl_device
+from numba_dppy.retarget import offload_to_sycl_device, get_context_manager
 
 from . import config
 
@@ -533,4 +533,4 @@ from ._version import get_versions
 __version__ = get_versions()["version"]
 del get_versions
 
-__all__ = ["offload_to_sycl_device"]
+__all__ = ["offload_to_sycl_device", "get_context_manager"]

--- a/numba_dppy/__init__.py
+++ b/numba_dppy/__init__.py
@@ -518,7 +518,7 @@ Supported NumPy Functions:
 import numba.testing
 
 from numba_dppy.interop import asarray
-from numba_dppy.retarget import get_context_manager, offload_to_sycl_device
+from numba_dppy.retarget import offload_to_sycl_device
 
 from . import config
 
@@ -533,4 +533,4 @@ from ._version import get_versions
 __version__ = get_versions()["version"]
 del get_versions
 
-__all__ = ["offload_to_sycl_device", "get_context_manager"]
+__all__ = ["offload_to_sycl_device"]

--- a/numba_dppy/__init__.py
+++ b/numba_dppy/__init__.py
@@ -518,7 +518,7 @@ Supported NumPy Functions:
 import numba.testing
 
 from numba_dppy.interop import asarray
-from numba_dppy.retarget import offload_to_sycl_device, get_context_manager
+from numba_dppy.retarget import get_context_manager, offload_to_sycl_device
 
 from . import config
 

--- a/numba_dppy/examples/atomic_op.py
+++ b/numba_dppy/examples/atomic_op.py
@@ -49,7 +49,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         atomic_add[global_size, dppy.DEFAULT_LOCAL_SIZE](a)
 
     # Expected 100, because global_size = 100

--- a/numba_dppy/examples/auto_offload_examples/sum-1d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-1d.py
@@ -44,7 +44,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         c = f1(a, b)
 
     print("RESULT c:", c, hex(c.ctypes.data))

--- a/numba_dppy/examples/auto_offload_examples/sum-2d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-2d.py
@@ -42,7 +42,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         c = f1(a, b)
 
     print("c:", c, hex(c.ctypes.data))

--- a/numba_dppy/examples/auto_offload_examples/sum-3d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-3d.py
@@ -42,7 +42,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         c = f1(a, b)
 
     print("c:", c, hex(c.ctypes.data))

--- a/numba_dppy/examples/auto_offload_examples/sum-4d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-4d.py
@@ -42,7 +42,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         c = f1(a, b)
 
     print("c:", c, hex(c.ctypes.data))

--- a/numba_dppy/examples/auto_offload_examples/sum-5d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-5d.py
@@ -42,7 +42,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         c = f1(a, b)
 
     print("c:", c, hex(c.ctypes.data))

--- a/numba_dppy/examples/barrier.py
+++ b/numba_dppy/examples/barrier.py
@@ -44,7 +44,7 @@ def no_arg_barrier_support():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         twice[N, dppy.DEFAULT_LOCAL_SIZE](arr)
 
     # the output should be `arr * 2, i.e. [0, 2, 4, 6, ...]`
@@ -80,7 +80,7 @@ def local_memory():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         reverse_array[blocksize, dppy.DEFAULT_LOCAL_SIZE](arr)
 
     # the output should be `orig[::-1] + orig, i.e. [9, 9, 9, ...]``

--- a/numba_dppy/examples/blacksholes_kernel.py
+++ b/numba_dppy/examples/blacksholes_kernel.py
@@ -90,7 +90,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         for i in range(iterations):
             black_scholes_dppy[blockdim, griddim](
                 callResult,

--- a/numba_dppy/examples/blacksholes_njit.py
+++ b/numba_dppy/examples/blacksholes_njit.py
@@ -78,7 +78,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         run(iter)
 
     print("Done...")

--- a/numba_dppy/examples/debug/dppy_func.py
+++ b/numba_dppy/examples/debug/dppy_func.py
@@ -53,7 +53,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         driver(a, b, c, global_size)
 
     print("Done...")

--- a/numba_dppy/examples/debug/dppy_numba_basic.py
+++ b/numba_dppy/examples/debug/dppy_numba_basic.py
@@ -67,7 +67,7 @@ def main():
 
     if args.api == "numba-dppy":
         device = dpctl.select_default_device()
-        with dppy.offload_to_sycl_device(device):
+        with dpctl.device_context(device):
             dppy_kernel[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
     else:
         numba_func_driver(a, b, c)

--- a/numba_dppy/examples/debug/simple_dppy_func.py
+++ b/numba_dppy/examples/debug/simple_dppy_func.py
@@ -36,7 +36,7 @@ b = np.arange(global_size, dtype=np.float32)
 c = np.empty_like(a)
 
 device = dpctl.SyclDevice("opencl:gpu")
-with dppy.offload_to_sycl_device(device):
+with dpctl.device_context(device):
     kernel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
 
 print("Done...")

--- a/numba_dppy/examples/debug/simple_sum.py
+++ b/numba_dppy/examples/debug/simple_sum.py
@@ -32,7 +32,7 @@ b = np.array(np.random.random(N), dtype=np.float32)
 c = np.ones_like(a)
 
 device = dpctl.SyclDevice("opencl:gpu")
-with dppy.offload_to_sycl_device(device):
+with dpctl.device_context(device):
     data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
 
 print("Done...")

--- a/numba_dppy/examples/debug/sum.py
+++ b/numba_dppy/examples/debug/sum.py
@@ -48,7 +48,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         driver(a, b, c, global_size)
 
     print("Done...")

--- a/numba_dppy/examples/debug/sum_local_vars.py
+++ b/numba_dppy/examples/debug/sum_local_vars.py
@@ -34,7 +34,7 @@ b = np.array(np.random.random(N), dtype=np.float32)
 c = np.ones_like(a)
 
 device = dpctl.SyclDevice("opencl:gpu")
-with dppy.offload_to_sycl_device(device):
+with dpctl.device_context(device):
     data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
 
 print("Done...")

--- a/numba_dppy/examples/debug/sum_local_vars_revive.py
+++ b/numba_dppy/examples/debug/sum_local_vars_revive.py
@@ -40,7 +40,7 @@ b = np.array(np.random.random(N), dtype=np.float32)
 c = np.ones_like(a)
 
 device = dpctl.SyclDevice("opencl:gpu")
-with dppy.offload_to_sycl_device(device):
+with dpctl.device_context(device):
     data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
 
 print("Done...")

--- a/numba_dppy/examples/dppy_func.py
+++ b/numba_dppy/examples/dppy_func.py
@@ -56,7 +56,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         driver(a, b, N)
 
     print("Done...")

--- a/numba_dppy/examples/dppy_with_context.py
+++ b/numba_dppy/examples/dppy_with_context.py
@@ -17,7 +17,7 @@ The numba_dppy extension adds an automatic offload optimizer to
 numba. The optimizer automatically detects data-parallel code
 regions in a numba.jit function and then offloads the data-parallel
 regions to a SYCL device. The optimizer is triggered when a numba.jit
-function is invoked inside ``numba_dppy.offload_to_sycl_device`` scope.
+function is invoked inside ``dpctl.device_context`` scope.
 
 This example demonstrates the usage of numba_dppy's automatic offload
 functionality. Note that numba_dppy should be installed in your
@@ -27,8 +27,6 @@ environment for the example to work.
 import dpctl
 import numpy as np
 from numba import njit, prange
-
-import numba_dppy as dppy
 
 
 @njit

--- a/numba_dppy/examples/dppy_with_context.py
+++ b/numba_dppy/examples/dppy_with_context.py
@@ -51,7 +51,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         result = add_two_arrays(b, c)
 
     print("Result :", result)

--- a/numba_dppy/examples/matmul.py
+++ b/numba_dppy/examples/matmul.py
@@ -58,7 +58,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         driver(a, b, c)
 
     # Host compute using standard NumPy

--- a/numba_dppy/examples/pairwise_distance.py
+++ b/numba_dppy/examples/pairwise_distance.py
@@ -94,7 +94,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         times = driver()
 
     times = np.asarray(times, dtype=np.float32)

--- a/numba_dppy/examples/rand.py
+++ b/numba_dppy/examples/rand.py
@@ -57,7 +57,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         result = rand()
         # Random values in a given shape (3, 2)
         print(result)

--- a/numba_dppy/examples/rand.py
+++ b/numba_dppy/examples/rand.py
@@ -17,14 +17,12 @@ numba_dppy can run several of the numpy.random RNG functions called inside
 a JIT function on a SYCL device using dpnp
 (https://github.com/IntelPython/dpnp). As with the rest of numba_dppy examples,
 this feature is also available by simply invoking a ``numba.jit`` function with
-the numpy.random calls from within a ``numba_dppy.offload_to_sycl_device``scope.
+the numpy.random calls from within a ``dpctl.device_context``scope.
 """
 
 import dpctl
 import numba
 import numpy as np
-
-import numba_dppy as dppy
 
 
 @numba.njit

--- a/numba_dppy/examples/sum.py
+++ b/numba_dppy/examples/sum.py
@@ -53,7 +53,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         driver(a, b, c, global_size)
 
     print("Done...")

--- a/numba_dppy/examples/sum2D.py
+++ b/numba_dppy/examples/sum2D.py
@@ -52,7 +52,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         driver(a, b, c, global_size)
 
     print(c)

--- a/numba_dppy/examples/sum_ndarray.py
+++ b/numba_dppy/examples/sum_ndarray.py
@@ -45,7 +45,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         print("before A: ", a)
         print("before B: ", b)
         data_parallel_sum[global_size, local_size](a, b, c)

--- a/numba_dppy/examples/sum_reduction.py
+++ b/numba_dppy/examples/sum_reduction.py
@@ -41,7 +41,7 @@ def sum_reduce(A):
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         while total > 1:
             global_size = total // 2
             sum_reduction_kernel[global_size, dppy.DEFAULT_LOCAL_SIZE](

--- a/numba_dppy/examples/sum_reduction_ocl.py
+++ b/numba_dppy/examples/sum_reduction_ocl.py
@@ -65,7 +65,7 @@ def sum_reduce(A):
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         sum_reduction_kernel[global_size, work_group_size](A, partial_sums)
 
     final_sum = 0

--- a/numba_dppy/examples/sum_reduction_recursive_ocl.py
+++ b/numba_dppy/examples/sum_reduction_recursive_ocl.py
@@ -99,7 +99,7 @@ def sum_reduce(A):
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         inp_buf = dpctl_mem.MemoryUSMShared(A.size * A.dtype.itemsize)
         inp_ndarray = np.ndarray(A.shape, buffer=inp_buf, dtype=A.dtype)
         np.copyto(inp_ndarray, A)

--- a/numba_dppy/examples/usm_ndarray.py
+++ b/numba_dppy/examples/usm_ndarray.py
@@ -54,7 +54,7 @@ def main():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         da = dpt.usm_ndarray(a.shape, dtype=a.dtype, buffer="shared")
         da.usm_data.copy_from_host(a.reshape((-1)).view("|u1"))
 

--- a/numba_dppy/examples/vectorize.py
+++ b/numba_dppy/examples/vectorize.py
@@ -49,7 +49,7 @@ def test_njit():
     print("Using device ...")
     device.print_device_info()
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         C = ufunc_kernel(A, B)
 
     print(C)

--- a/numba_dppy/retarget.py
+++ b/numba_dppy/retarget.py
@@ -57,11 +57,9 @@ def _retarget_context_manager(sycl_queue):
     return TargetConfig.switch_target(retarget)
 
 
-@contextmanager
-def offload_to_sycl_device(dpctl_device):
-    with dpctl.device_context(dpctl_device) as sycl_queue:
-        with _retarget_context_manager(sycl_queue):
-            yield sycl_queue
+def _register_context_factory():
+    dpctl.nested_context_factories.append(_retarget_context_manager)
 
 
-get_context_manager = _retarget_context_manager
+_register_context_factory()
+offload_to_sycl_device = dpctl.device_context

--- a/numba_dppy/tests/integration/test_dpnp_interop.py
+++ b/numba_dppy/tests/integration/test_dpnp_interop.py
@@ -88,7 +88,7 @@ def test_consuming_array_from_dpnp(offload_device, dtype):
 
     global_size = 1021
 
-    with dppy.offload_to_sycl_device(offload_device):
+    with dpctl.device_context(offload_device):
         a = dppy.asarray(dpnp.arange(global_size, dtype=dtype))
         b = dppy.asarray(dpnp.arange(global_size, dtype=dtype))
         c = dppy.asarray(dpnp.ones_like(a))

--- a/numba_dppy/tests/integration/test_usm_ndarray_interop.py
+++ b/numba_dppy/tests/integration/test_usm_ndarray_interop.py
@@ -66,7 +66,7 @@ def test_consuming_usm_ndarray(offload_device, dtype, usm_type):
 
     got = np.ones_like(a)
 
-    with dppy.offload_to_sycl_device(offload_device) as gpu_queue:
+    with dpctl.device_context(offload_device) as gpu_queue:
         da = dpt.usm_ndarray(
             a.shape,
             dtype=a.dtype,

--- a/numba_dppy/tests/kernel_tests/test_arg_accessor.py
+++ b/numba_dppy/tests/kernel_tests/test_arg_accessor.py
@@ -79,6 +79,6 @@ def test_kernel_arg_accessor(filter_str, input_arrays, kernel):
     a, b, actual = input_arrays
     expected = a + b
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         call_kernel(global_size, local_size, a, b, actual, kernel)
     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=0)

--- a/numba_dppy/tests/kernel_tests/test_arg_types.py
+++ b/numba_dppy/tests/kernel_tests/test_arg_types.py
@@ -65,7 +65,7 @@ def test_kernel_arg_types(filter_str, input_arrays):
     a, actual, c = input_arrays
     expected = a * c
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         kernel[global_size, local_size](a, actual, c)
     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=0)
 
@@ -85,7 +85,7 @@ def test_bool_type(filter_str):
     a = np.array([2], np.int64)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         kernel[a.size, dppy.DEFAULT_LOCAL_SIZE](a, True)
         assert a[0] == 111
         kernel[a.size, dppy.DEFAULT_LOCAL_SIZE](a, False)

--- a/numba_dppy/tests/kernel_tests/test_atomic_op.py
+++ b/numba_dppy/tests/kernel_tests/test_atomic_op.py
@@ -105,7 +105,7 @@ def test_kernel_atomic_simple(filter_str, input_arrays, kernel_result_pair):
     a, dtype = input_arrays
     kernel, expected = kernel_result_pair
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         kernel[global_size, dppy.DEFAULT_LOCAL_SIZE](a)
     assert a[0] == expected
 
@@ -133,7 +133,7 @@ def test_kernel_atomic_local(filter_str, input_arrays, return_list_of_op):
     f = get_func_local(op_type, dtype)
     kernel = dppy.kernel(f)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         kernel[global_size, global_size](a)
     assert a[0] == expected
 
@@ -176,7 +176,7 @@ def test_kernel_atomic_multi_dim(
     kernel = get_kernel_multi_dim(op_type, len(dim))
     a = np.zeros(dim, return_dtype)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         kernel[global_size, dppy.DEFAULT_LOCAL_SIZE](a)
     assert a[0] == expected
 
@@ -218,7 +218,7 @@ def test_atomic_fp_native(filter_str, return_list_of_op, fdtype, addrspace):
     LLVM_SPIRV_ROOT_old_val = config.LLVM_SPIRV_ROOT
     config.LLVM_SPIRV_ROOT = LLVM_SPIRV_ROOT
 
-    with dppy.offload_to_sycl_device(filter_str) as sycl_queue:
+    with dpctl.device_context(filter_str) as sycl_queue:
         kern = kernel[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(
             kernel._get_argtypes(a), sycl_queue
         )
@@ -231,7 +231,7 @@ def test_atomic_fp_native(filter_str, return_list_of_op, fdtype, addrspace):
 
     # To bypass caching
     kernel = dppy.kernel(f)
-    with dppy.offload_to_sycl_device(filter_str) as sycl_queue:
+    with dpctl.device_context(filter_str) as sycl_queue:
         kern = kernel[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(
             kernel._get_argtypes(a), sycl_queue
         )

--- a/numba_dppy/tests/kernel_tests/test_barrier.py
+++ b/numba_dppy/tests/kernel_tests/test_barrier.py
@@ -63,7 +63,7 @@ def test_proper_lowering(filter_str):
     arr = np.random.random(N).astype(np.float32)
     orig = arr.copy()
 
-    with dppy.offload_to_sycl_device(filter_str):
+    with dpctl.device_context(filter_str):
         twice[N, N // 2](arr)
 
     # The computation is correct?
@@ -89,7 +89,7 @@ def test_no_arg_barrier_support(filter_str):
     arr = np.random.random(N).astype(np.float32)
     orig = arr.copy()
 
-    with dppy.offload_to_sycl_device(filter_str):
+    with dpctl.device_context(filter_str):
         twice[N, dppy.DEFAULT_LOCAL_SIZE](arr)
 
     # The computation is correct?
@@ -119,7 +119,7 @@ def test_local_memory(filter_str):
     arr = np.arange(blocksize).astype(np.float32)
     orig = arr.copy()
 
-    with dppy.offload_to_sycl_device(filter_str):
+    with dpctl.device_context(filter_str):
         reverse_array[blocksize, blocksize](arr)
 
     expected = orig[::-1] + orig

--- a/numba_dppy/tests/kernel_tests/test_caching.py
+++ b/numba_dppy/tests/kernel_tests/test_caching.py
@@ -51,7 +51,7 @@ def test_caching_kernel_using_same_queue(filter_str):
     b = np.array(np.random.random(N), dtype=np.float32)
     c = np.ones_like(a)
 
-    with dppy.offload_to_sycl_device(filter_str) as gpu_queue:
+    with dpctl.device_context(filter_str) as gpu_queue:
         func = dppy.kernel(data_parallel_sum)
         cached_kernel = func[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(
             func._get_argtypes(a, b, c), gpu_queue
@@ -94,7 +94,7 @@ def test_caching_kernel_using_same_context(filter_str):
     )
     for i in range(0, 10):
         # Each iteration create a fresh queue that will share the same context
-        with dppy.offload_to_sycl_device(filter_str) as gpu_queue:
+        with dpctl.device_context(filter_str) as gpu_queue:
             _kernel = func[global_size, dppy.DEFAULT_LOCAL_SIZE].specialize(
                 func._get_argtypes(a, b, c), gpu_queue
             )

--- a/numba_dppy/tests/kernel_tests/test_math_functions.py
+++ b/numba_dppy/tests/kernel_tests/test_math_functions.py
@@ -70,7 +70,7 @@ def test_binary_ops(filter_str, unary_op, input_arrays):
         b[i] = uop(a[i])
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         f[a.size, dppy.DEFAULT_LOCAL_SIZE](a, actual)
 
     expected = np_uop(a)

--- a/numba_dppy/tests/kernel_tests/test_print.py
+++ b/numba_dppy/tests/kernel_tests/test_print.py
@@ -33,7 +33,7 @@ def filter_str(request):
 def test_print_only_str(filter_str):
     try:
         device = dpctl.SyclDevice(filter_str)
-        with dppy.offload_to_sycl_device(device):
+        with dpctl.device_context(device):
             pass
     except Exception:
         pytest.skip()
@@ -48,7 +48,7 @@ def test_print_only_str(filter_str):
     # puts function signature right now, and would fail in general due
     # to lack of support for puts() in OpenCL.
 
-    with dppy.offload_to_sycl_device(filter_str):
+    with dpctl.device_context(filter_str):
         f[3, dppy.DEFAULT_LOCAL_SIZE]()
 
 
@@ -79,7 +79,7 @@ def test_print(filter_str, input_arrays, capfd):
     global_size = 3
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         f[global_size, dppy.DEFAULT_LOCAL_SIZE](a)
         captured = capfd.readouterr()
         assert "test" in captured.out

--- a/numba_dppy/tests/kernel_tests/test_return_type.py
+++ b/numba_dppy/tests/kernel_tests/test_return_type.py
@@ -45,5 +45,5 @@ def test_return(offload_device, sig):
         kernel = dppy.kernel(sig)(f)
 
         device = dpctl.SyclDevice(offload_device)
-        with dppy.offload_to_sycl_device(device):
+        with dpctl.device_context(device):
             kernel[a.size, dppy.DEFAULT_LOCAL_SIZE](a)

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_creation.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_creation.py
@@ -105,7 +105,7 @@ def test_unary_ops(filter_str, unary_op, input_array, capfd):
 
     f = njit(fn)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -130,7 +130,7 @@ def test_binary_op(filter_str, binary_op, input_array, dtype, get_shape, capfd):
 
     f = njit(fn)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a, dtype)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -160,7 +160,7 @@ def test_full(filter_str, full_name, input_array, get_shape, capfd):
 
     f = njit(fn)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a, np.array([2]))
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_ops.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_ops.py
@@ -113,7 +113,7 @@ def test_unary_ops(filter_str, unary_op, input_arrays, get_shape, capfd):
 
     f = njit(op)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -149,7 +149,7 @@ def test_take(filter_str, input_arrays, indices, capfd):
 
     f = njit(fn)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a, indices)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_indexing.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_indexing.py
@@ -81,7 +81,7 @@ def test_diagonal(array, offset, filter_str):
 
     f = njit(fn)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a, offset)
 
     expected = fn(a, offset)

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_linalg.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_linalg.py
@@ -97,7 +97,7 @@ def test_eig(filter_str, eig_input, capfd):
     f = njit(fn)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual_val, actual_vec = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -169,7 +169,7 @@ def test_dot(filter_str, dot_name, dot_input, dtype, capfd):
     f = njit(fn)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a, b)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -189,7 +189,7 @@ def test_matmul(filter_str, dtype, capfd):
     f = njit(fn)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a, b)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -208,7 +208,7 @@ def test_cholesky(filter_str, dtype, capfd):
     f = njit(fn)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -244,7 +244,7 @@ def test_det(filter_str, det_input, dtype, capfd):
     f = njit(fn)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -269,7 +269,7 @@ def test_multi_dot(filter_str, capfd):
     f = njit(fn)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(A, B, C, D)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -308,7 +308,7 @@ def test_matrix_power(filter_str, matrix_power_input, power, dtype, capfd):
     f = njit(fn)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a, power)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -340,7 +340,7 @@ def test_matrix_rank(filter_str, matrix_rank_input, capfd):
     f = njit(fn)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(matrix_rank_input)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -359,7 +359,7 @@ def test_eigvals(filter_str, eig_input, capfd):
     f = njit(fn)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual_val = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_logic.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_logic.py
@@ -16,11 +16,11 @@
 # limitations under the License.
 ################################################################################
 
+import dpctl
 import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import dpnp_debug
 
 from .dpnp_skip_test import dpnp_skip_test as skip_test
@@ -68,7 +68,7 @@ def test_all(dtype, shape, filter_str):
             return np.all(a)
 
         f = njit(fn)
-        with dppy.offload_to_sycl_device(filter_str), dpnp_debug():
+        with dpctl.device_context(filter_str), dpnp_debug():
             actual = f(a)
 
         expected = fn(a)

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_manipulation.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_manipulation.py
@@ -54,7 +54,7 @@ def test_repeat(filter_str, arr):
         return np.repeat(a, repeats)
 
     f = njit(fn)
-    with dppy.offload_to_sycl_device(filter_str), dpnp_debug():
+    with dpctl.device_context(filter_str), dpnp_debug():
         actual = f(a, repeats)
 
     expected = fn(a, repeats)

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_rng.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_rng.py
@@ -87,7 +87,7 @@ def test_one_arg_fn(filter_str, one_arg_fn, unary_size, capfd):
     name, low, high = params
     f = njit(op)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(unary_size)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -130,7 +130,7 @@ def test_two_arg_fn(filter_str, two_arg_fn, unary_size, capfd):
     op = get_two_arg_fn(op_name)
     f = njit(op)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(first_arg, unary_size)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -189,7 +189,7 @@ def test_three_arg_fn(filter_str, three_arg_fn, three_arg_size, capfd):
     op = get_three_arg_fn(op_name)
     f = njit(op)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(first_arg, second_arg, three_arg_size)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -224,7 +224,7 @@ def test_rand(filter_str):
         return c
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f()
 
         actual = actual.ravel()
@@ -243,7 +243,7 @@ def test_hypergeometric(filter_str, three_arg_size):
 
     ngood, nbad, nsamp = 100, 2, 10
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(ngood, nbad, nsamp, three_arg_size)
 
         if np.isscalar(actual):

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_sort_search_count.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_sort_search_count.py
@@ -93,7 +93,7 @@ def test_unary_ops(filter_str, unary_op, input_arrays, get_shape, capfd):
 
     f = njit(op)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -133,7 +133,7 @@ def test_partition(array, kth, filter_str):
 
     f = njit(fn)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a, kth)
 
     expected = fn(a, kth)

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_statistics.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_statistics.py
@@ -100,7 +100,7 @@ def test_unary_ops(filter_str, unary_op, input_arrays, get_shape, capfd):
 
     f = njit(op)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_transcendentals.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_transcendentals.py
@@ -126,7 +126,7 @@ def test_unary_ops(filter_str, unary_op, input_array, get_shape, capfd):
 
     f = njit(op)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out
@@ -151,7 +151,7 @@ def test_unary_nan_ops(filter_str, unary_nan_op, input_nan_array, get_shape, cap
 
     f = njit(op)
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), dpnp_debug():
+    with dpctl.device_context(device), dpnp_debug():
         actual = f(a)
         captured = capfd.readouterr()
         assert "dpnp implementation" in captured.out

--- a/numba_dppy/tests/njit_tests/test_numpy_bitwise_ops.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_bitwise_ops.py
@@ -90,7 +90,7 @@ def test_binary_ops(filter_str, binary_op, input_arrays):
         return binop(a, b)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), assert_auto_offloading():
+    with dpctl.device_context(device), assert_auto_offloading():
         actual = f(a, b)
 
     expected = binop(a, b)
@@ -111,7 +111,7 @@ def test_unary_ops(filter_str, unary_op, input_arrays):
         return uop(a)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), assert_auto_offloading():
+    with dpctl.device_context(device), assert_auto_offloading():
         actual = f(a)
 
     expected = uop(a)

--- a/numba_dppy/tests/njit_tests/test_numpy_logic_ops.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_logic_ops.py
@@ -97,7 +97,7 @@ def test_binary_ops(filter_str, binary_op, input_arrays):
         return binop(a, b)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), assert_auto_offloading():
+    with dpctl.device_context(device), assert_auto_offloading():
         actual = f(a, b)
 
     expected = binop(a, b)
@@ -118,7 +118,7 @@ def test_unary_ops(filter_str, unary_op, input_arrays):
         return uop(a)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), assert_auto_offloading():
+    with dpctl.device_context(device), assert_auto_offloading():
         actual = f(a)
 
     expected = uop(a)

--- a/numba_dppy/tests/njit_tests/test_numpy_transcedental_functions.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_transcedental_functions.py
@@ -117,7 +117,7 @@ def test_binary_ops(filter_str, binary_op, input_arrays):
         return binop(a, b)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), assert_auto_offloading():
+    with dpctl.device_context(device), assert_auto_offloading():
         actual = f(a, b)
 
     expected = binop(a, b)
@@ -143,7 +143,7 @@ def test_unary_ops(filter_str, unary_op, input_arrays):
         return uop(a)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), assert_auto_offloading():
+    with dpctl.device_context(device), assert_auto_offloading():
         actual = f(a)
 
     expected = uop(a)

--- a/numba_dppy/tests/njit_tests/test_numpy_trigonometric_functions.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_trigonometric_functions.py
@@ -107,7 +107,7 @@ def test_trigonometric_fn(filter_str, trig_op, input_arrays):
             return trig_fn(a, b)
 
         device = dpctl.SyclDevice(filter_str)
-        with dppy.offload_to_sycl_device(device), assert_auto_offloading():
+        with dpctl.device_context(device), assert_auto_offloading():
             actual = f(a, b)
         expected = trig_fn(a, b)
     else:
@@ -117,7 +117,7 @@ def test_trigonometric_fn(filter_str, trig_op, input_arrays):
             return trig_fn(a)
 
         device = dpctl.SyclDevice(filter_str)
-        with dppy.offload_to_sycl_device(device), assert_auto_offloading():
+        with dpctl.device_context(device), assert_auto_offloading():
             actual = f(a)
         expected = trig_fn(a)
 

--- a/numba_dppy/tests/test_black_scholes.py
+++ b/numba_dppy/tests/test_black_scholes.py
@@ -16,6 +16,7 @@ import math
 import time
 import unittest
 
+import dpctl
 import numpy as np
 
 import numba_dppy as dppy
@@ -131,7 +132,7 @@ class TestDPPYBlackScholes(unittest.TestCase):
         blockdim = 512, 1
         griddim = int(math.ceil(float(OPT_N) / blockdim[0])), 1
 
-        with dppy.offload_to_sycl_device("opencl:gpu"):
+        with dpctl.device_context("opencl:gpu"):
             time1 = time.time()
             for i in range(iterations):
                 black_scholes_dppy[blockdim, griddim](

--- a/numba_dppy/tests/test_controllable_fallback.py
+++ b/numba_dppy/tests/test_controllable_fallback.py
@@ -19,7 +19,6 @@ import dpctl
 import numba
 import numpy as np
 
-import numba_dppy
 from numba_dppy import config
 
 from . import _helper
@@ -44,7 +43,7 @@ class TestDPPYFallback(unittest.TestCase):
         config.DEBUG = 1
         with warnings.catch_warnings(record=True) as w:
             device = dpctl.SyclDevice("opencl:gpu")
-            with numba_dppy.offload_to_sycl_device(device):
+            with dpctl.device_context(device):
                 dppy = numba.njit(parallel=True)(inner_call_fallback)
                 dppy_fallback_true = dppy()
 
@@ -74,7 +73,7 @@ class TestDPPYFallback(unittest.TestCase):
             config.FALLBACK_ON_CPU = 0
             with warnings.catch_warnings(record=True) as w:
                 device = dpctl.SyclDevice("opencl:gpu")
-                with numba_dppy.offload_to_sycl_device(device):
+                with dpctl.device_context(device):
                     dppy = numba.njit(parallel=True)(inner_call_fallback)
                     dppy_fallback_false = dppy()
 

--- a/numba_dppy/tests/test_device_array_args.py
+++ b/numba_dppy/tests/test_device_array_args.py
@@ -42,7 +42,7 @@ class TestDPPYDeviceArrayArgsGPU(unittest.TestCase):
     def test_device_array_args_cpu(self):
         c = np.ones_like(a)
 
-        with dppy.offload_to_sycl_device("opencl:cpu"):
+        with dpctl.device_context("opencl:cpu"):
             data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
 
             self.assertTrue(np.all(c == d))
@@ -53,7 +53,7 @@ class TestDPPYDeviceArrayArgsCPU(unittest.TestCase):
     def test_device_array_args_gpu(self):
         c = np.ones_like(a)
 
-        with dppy.offload_to_sycl_device("opencl:gpu"):
+        with dpctl.device_context("opencl:gpu"):
             data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
 
         self.assertTrue(np.all(c == d))

--- a/numba_dppy/tests/test_dpctl_api.py
+++ b/numba_dppy/tests/test_dpctl_api.py
@@ -35,7 +35,7 @@ def test_dpctl_api(filter_str):
         pytest.skip()
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         dpctl.lsplatform()
         dpctl.get_current_queue()
         dpctl.get_num_activated_queues()

--- a/numba_dppy/tests/test_dpnp_functions.py
+++ b/numba_dppy/tests/test_dpnp_functions.py
@@ -47,9 +47,7 @@ class Testdpnp_functions(unittest.TestCase):
             return d
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with dpctl.device_context(
-            device
-        ), assert_auto_offloading(), dpnp_debug():
+        with dpctl.device_context(device), assert_auto_offloading(), dpnp_debug():
             njit_f = njit(f)
             got = njit_f(self.a, self.b)
         expected = f(self.a, self.b)

--- a/numba_dppy/tests/test_dpnp_functions.py
+++ b/numba_dppy/tests/test_dpnp_functions.py
@@ -47,7 +47,7 @@ class Testdpnp_functions(unittest.TestCase):
             return d
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with dppy.offload_to_sycl_device(
+        with dpctl.device_context(
             device
         ), assert_auto_offloading(), dpnp_debug():
             njit_f = njit(f)

--- a/numba_dppy/tests/test_dppy_fallback.py
+++ b/numba_dppy/tests/test_dppy_fallback.py
@@ -19,8 +19,6 @@ import dpctl
 import numba
 import numpy as np
 
-import numba_dppy
-
 from . import _helper
 
 
@@ -43,7 +41,7 @@ class TestDPPYFallback(unittest.TestCase):
         device = dpctl.SyclDevice("opencl:gpu")
         with warnings.catch_warnings(
             record=True
-        ) as w, numba_dppy.offload_to_sycl_device(device):
+        ) as w, dpctl.device_context(device):
             dppy = numba.njit(inner_call_fallback)
             dppy_result = dppy()
 
@@ -63,7 +61,7 @@ class TestDPPYFallback(unittest.TestCase):
         device = dpctl.SyclDevice("opencl:gpu")
         with warnings.catch_warnings(
             record=True
-        ) as w, numba_dppy.offload_to_sycl_device(device):
+        ) as w, dpctl.device_context(device):
             dppy = numba.njit(reduction)
             dppy_result = dppy(a)
 

--- a/numba_dppy/tests/test_dppy_fallback.py
+++ b/numba_dppy/tests/test_dppy_fallback.py
@@ -39,9 +39,7 @@ class TestDPPYFallback(unittest.TestCase):
             return a
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with warnings.catch_warnings(
-            record=True
-        ) as w, dpctl.device_context(device):
+        with warnings.catch_warnings(record=True) as w, dpctl.device_context(device):
             dppy = numba.njit(inner_call_fallback)
             dppy_result = dppy()
 
@@ -59,9 +57,7 @@ class TestDPPYFallback(unittest.TestCase):
 
         a = np.ones(10)
         device = dpctl.SyclDevice("opencl:gpu")
-        with warnings.catch_warnings(
-            record=True
-        ) as w, dpctl.device_context(device):
+        with warnings.catch_warnings(record=True) as w, dpctl.device_context(device):
             dppy = numba.njit(reduction)
             dppy_result = dppy(a)
 

--- a/numba_dppy/tests/test_dppy_func.py
+++ b/numba_dppy/tests/test_dppy_func.py
@@ -40,7 +40,7 @@ class TestDPPYFunc(unittest.TestCase):
         b = np.ones(self.N)
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with dppy.offload_to_sycl_device(device):
+        with dpctl.device_context(device):
             f[self.N, dppy.DEFAULT_LOCAL_SIZE](a, b)
 
         self.assertTrue(np.all(b == 2))
@@ -64,7 +64,7 @@ class TestDPPYFunc(unittest.TestCase):
         b = np.ones(self.N)
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with dppy.offload_to_sycl_device(device):
+        with dpctl.device_context(device):
             f[self.N, dppy.DEFAULT_LOCAL_SIZE](a, b)
 
             self.assertTrue(np.all(b == 2))

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -50,7 +50,7 @@ def test_no_copy_usm_shared(capfd):
     except ValueError:
         pytest.skip("Device not found")
 
-    with dppy.offload_to_sycl_device(device):
+    with dpctl.device_context(device):
         cres = compiler.compile_extra(
             typingctx=typingctx,
             targetctx=targetctx,

--- a/numba_dppy/tests/test_offload_diagnostics.py
+++ b/numba_dppy/tests/test_offload_diagnostics.py
@@ -39,7 +39,7 @@ class TestOffloadDiagnostics(unittest.TestCase):
             return a
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with dppy.offload_to_sycl_device(device):
+        with dpctl.device_context(device):
             dppy_config.OFFLOAD_DIAGNOSTICS = 1
             jitted = njit(parallel=True)(prange_func)
 
@@ -64,7 +64,7 @@ class TestOffloadDiagnostics(unittest.TestCase):
         c = np.ones_like(a)
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with dppy.offload_to_sycl_device(device):
+        with dpctl.device_context(device):
             dppy_config.OFFLOAD_DIAGNOSTICS = 1
 
             with captured_stdout() as got:

--- a/numba_dppy/tests/test_parfor_lower_message.py
+++ b/numba_dppy/tests/test_parfor_lower_message.py
@@ -40,7 +40,7 @@ def prange_example():
 class TestParforMessage(unittest.TestCase):
     def test_parfor_message(self):
         device = dpctl.SyclDevice("opencl:gpu")
-        with dppy.offload_to_sycl_device(device):
+        with dpctl.device_context(device):
             config.DEBUG = 1
             jitted = njit(prange_example)
 

--- a/numba_dppy/tests/test_prange.py
+++ b/numba_dppy/tests/test_prange.py
@@ -85,9 +85,7 @@ class TestPrange(unittest.TestCase):
         b = np.ones((m, n))
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(parfor_offloaded=2), dpctl.device_context(
-            device
-        ):
+        with assert_auto_offloading(parfor_offloaded=2), dpctl.device_context(device):
             f(a, b)
 
         self.assertTrue(np.all(b == 10))
@@ -112,9 +110,7 @@ class TestPrange(unittest.TestCase):
         b = np.ones((m, n, o))
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(parfor_offloaded=1), dpctl.device_context(
-            device
-        ):
+        with assert_auto_offloading(parfor_offloaded=1), dpctl.device_context(device):
             f(a, b)
 
         self.assertTrue(np.all(b == 12))
@@ -134,9 +130,7 @@ class TestPrange(unittest.TestCase):
         jitted = njit(prange_example)
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(parfor_offloaded=2), dpctl.device_context(
-            device
-        ):
+        with assert_auto_offloading(parfor_offloaded=2), dpctl.device_context(device):
             jitted_res = jitted()
 
         res = prange_example()
@@ -158,9 +152,7 @@ class TestPrange(unittest.TestCase):
         jitted = njit(prange_example)
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(parfor_offloaded=2), dpctl.device_context(
-            device
-        ):
+        with assert_auto_offloading(parfor_offloaded=2), dpctl.device_context(device):
             jitted_res = jitted()
 
         res = prange_example()

--- a/numba_dppy/tests/test_prange.py
+++ b/numba_dppy/tests/test_prange.py
@@ -39,7 +39,7 @@ class TestPrange(unittest.TestCase):
         b = np.ones((m, n))
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(), dppy.offload_to_sycl_device(device):
+        with assert_auto_offloading(), dpctl.device_context(device):
             f(a, b)
 
         for i in range(4):
@@ -60,7 +60,7 @@ class TestPrange(unittest.TestCase):
         b = np.ones((m, n))
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(), dppy.offload_to_sycl_device(device):
+        with assert_auto_offloading(), dpctl.device_context(device):
             f(a, b)
 
         self.assertTrue(np.all(b == 10))
@@ -85,7 +85,7 @@ class TestPrange(unittest.TestCase):
         b = np.ones((m, n))
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(parfor_offloaded=2), dppy.offload_to_sycl_device(
+        with assert_auto_offloading(parfor_offloaded=2), dpctl.device_context(
             device
         ):
             f(a, b)
@@ -112,7 +112,7 @@ class TestPrange(unittest.TestCase):
         b = np.ones((m, n, o))
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(parfor_offloaded=1), dppy.offload_to_sycl_device(
+        with assert_auto_offloading(parfor_offloaded=1), dpctl.device_context(
             device
         ):
             f(a, b)
@@ -134,7 +134,7 @@ class TestPrange(unittest.TestCase):
         jitted = njit(prange_example)
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(parfor_offloaded=2), dppy.offload_to_sycl_device(
+        with assert_auto_offloading(parfor_offloaded=2), dpctl.device_context(
             device
         ):
             jitted_res = jitted()
@@ -158,7 +158,7 @@ class TestPrange(unittest.TestCase):
         jitted = njit(prange_example)
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with assert_auto_offloading(parfor_offloaded=2), dppy.offload_to_sycl_device(
+        with assert_auto_offloading(parfor_offloaded=2), dpctl.device_context(
             device
         ):
             jitted_res = jitted()

--- a/numba_dppy/tests/test_sum_reduction.py
+++ b/numba_dppy/tests/test_sum_reduction.py
@@ -45,7 +45,7 @@ class TestDPPYSumReduction(unittest.TestCase):
         R = np.array(np.random.random(math.ceil(N / 2)), dtype=np.float32)
 
         device = dpctl.SyclDevice("opencl:gpu")
-        with dppy.offload_to_sycl_device(device):
+        with dpctl.device_context(device):
             total = N
 
             while total > 1:

--- a/numba_dppy/tests/test_vectorize.py
+++ b/numba_dppy/tests/test_vectorize.py
@@ -65,7 +65,7 @@ def test_njit(filter_str):
     B = np.random.random(10)
 
     device = dpctl.SyclDevice(filter_str)
-    with dppy.offload_to_sycl_device(device), assert_auto_offloading():
+    with dpctl.device_context(device), assert_auto_offloading():
         f_njit = njit(f)
         expected = f_njit(A, B)
         actual = f(A, B)
@@ -116,7 +116,7 @@ def test_vectorize(filter_str, shape, dtypes, input_type):
         A = dtype(1.2)
         B = dtype(2.3)
 
-    with dppy.offload_to_sycl_device(filter_str):
+    with dpctl.device_context(filter_str):
         f = vectorize(sig, target="dppy")(vector_add)
         expected = f(A, B)
         actual = vector_add(A, B)

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -58,7 +58,7 @@ def scenario(filter_str, context):
 @pytest.mark.parametrize(
     "context",
     [
-        dppy.offload_to_sycl_device,
+        dpctl.device_context,
         dpctl.device_context,
     ],
 )
@@ -85,7 +85,7 @@ class TestWithDPPYContext(unittest.TestCase):
 
         with captured_stdout() as got_gpu_message:
             device = dpctl.SyclDevice("opencl:gpu")
-            with dppy.offload_to_sycl_device(device):
+            with dpctl.device_context(device):
                 func(got_gpu)
 
         config.DEBUG = 0
@@ -111,7 +111,7 @@ class TestWithDPPYContext(unittest.TestCase):
 
         with captured_stdout() as got_cpu_message:
             device = dpctl.SyclDevice("opencl:cpu")
-            with dppy.offload_to_sycl_device(device):
+            with dpctl.device_context(device):
                 func(got_cpu)
 
         config.DEBUG = 0

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -16,14 +16,52 @@ import unittest
 
 import dpctl
 import numpy as np
+import pytest
 from numba import njit
 from numba.tests.support import captured_stdout
 
-import numba_dppy
 import numba_dppy as dppy
 from numba_dppy import config
 
 from . import _helper
+from ._helper import assert_auto_offloading
+
+skip_no_gpu = pytest.mark.skipif(
+    not _helper.has_gpu_queues(), reason="No GPU platforms available"
+)
+skip_no_cpu = pytest.mark.skipif(
+    not _helper.has_cpu_queues(), reason="No CPU platforms available"
+)
+
+
+filter_strings = [
+    pytest.param("level_zero:gpu:0", marks=skip_no_gpu),
+    pytest.param("opencl:gpu:0", marks=skip_no_gpu),
+    pytest.param("opencl:cpu:0", marks=skip_no_cpu),
+]
+
+
+def scenario(filter_str, context):
+    @njit
+    def func(a, b):
+        return a + b
+
+    a = np.ones((64), dtype=np.int32)
+    b = np.ones((64), dtype=np.int32)
+
+    device = dpctl.SyclDevice(filter_str)
+    with context(device):
+        func(a, b)
+
+
+@pytest.mark.parametrize("filter_str", filter_strings)
+@pytest.mark.parametrize("context", [
+    dppy.offload_to_sycl_device,
+    dpctl.device_context,
+])
+def test_dpctl_device_context_affects_numba_pipeline(filter_str, context):
+    with assert_auto_offloading():
+        scenario(filter_str, context)
 
 
 class TestWithDPPYContext(unittest.TestCase):

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -55,10 +55,13 @@ def scenario(filter_str, context):
 
 
 @pytest.mark.parametrize("filter_str", filter_strings)
-@pytest.mark.parametrize("context", [
-    dppy.offload_to_sycl_device,
-    dpctl.device_context,
-])
+@pytest.mark.parametrize(
+    "context",
+    [
+        dppy.offload_to_sycl_device,
+        dpctl.device_context,
+    ],
+)
 def test_dpctl_device_context_affects_numba_pipeline(filter_str, context):
     with assert_auto_offloading():
         scenario(filter_str, context)

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -58,7 +58,7 @@ def scenario(filter_str, context):
 @pytest.mark.parametrize(
     "context",
     [
-        dpctl.device_context,
+        dppy.offload_to_sycl_device,
         dpctl.device_context,
     ],
 )


### PR DESCRIPTION
Relates to https://github.com/IntelPython/dpctl/pull/678.

Tasks:
- [x] docs
- [x] changelog
- [x] `dppy.offload_to_sycl_device` reuses `dpctl.device_context`
- [x] replace `dppy.offload_to_sycl_device` with `dpctl.device_context` in all tests
- [x] dpctl >=0.12 or >=0.11.2