### PR TITLE
Fix DeprecationWarning when use `version.parse()` [cherry picked from #639]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Enable offloading for `numba.njit` in `dpctl.deveice_context` (#630)
 * Fix upload conditions for main and release branches (#610)
+* Fix DeprecationWarning when use `version.parse()` [cherry picked from #639] (#642)
 
 ## [0.17.2] - 2021-11-15
 

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -36,7 +36,7 @@ try:
 
     # Versions of dpctl lower than 0.8.0 are not compatible with current main
     # of numba_dppy.
-    if version.parse(dpctl.__version__) < version.parse("0.8.*"):
+    if version.parse(dpctl.__version__) < version.parse("0.8.0"):
         raise DpctlMinimumVersionRequiredError
 
     # For the Numba_dppy extension to work, we should have at least one


### PR DESCRIPTION
From #639.