### PR TITLE
Pin numba 0.55 package for testing

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       matrix:
         python: [3.8, 3.9]
-        numba: [0.54, 0.55]
+        numba: [0.54, "0.55.0dev0=*_385"]
         integration_channels: [""]
         experimental: [true]  # packages are not available on -c intel yet
         artifact_name: [""]

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       matrix:
         python: [3.8, 3.9]
-        numba: [0.54, "0.55.0dev0=*_385"]
+        numba: [0.54, "0.55.0dev0=*_469"]
         integration_channels: [""]
         experimental: [true]  # packages are not available on -c intel yet
         artifact_name: [""]


### PR DESCRIPTION
The latest unreleased numba 0.55 package is not supported. It breaks CI. This PR pins package version with the latest supported package.