### PR TITLE
prep for dpctl/include reorg (IntelPython/dpctl#685)

### DIFF
--- a/numba_dppy/dpctl_iface/usm_shared_allocator_ext.c
+++ b/numba_dppy/dpctl_iface/usm_shared_allocator_ext.c
@@ -27,9 +27,19 @@
 #include "assert.h"
 #include <stdio.h>
 #include <stdbool.h>
-#include <dpctl_sycl_queue_interface.h>
-#include <dpctl_sycl_queue_manager.h>
-#include <dpctl_sycl_usm_interface.h>
+#if defined __has_include
+#  if __has_include(<dpctl_sycl_interface.h>)
+#    include <dpctl_sycl_interface.h>
+#  else
+#    include <dpctl_sycl_queue_interface.h>
+#    include <dpctl_sycl_queue_manager.h>
+#    include <dpctl_sycl_usm_interface.h>
+#  endif
+#else
+#  include <dpctl_sycl_queue_interface.h>
+#  include <dpctl_sycl_queue_manager.h>
+#  include <dpctl_sycl_usm_interface.h>
+#endif
 
 NRT_ExternalAllocator usmarray_allocator;
 NRT_external_malloc_func internal_allocator = NULL;


### PR DESCRIPTION
Use `__has_include` to work with both layouts.