### PR TITLE
Fix skipping for Level Zero device for "with context" test

### DIFF
--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -30,10 +30,13 @@ skip_no_gpu = pytest.mark.skipif(
 skip_no_cpu = pytest.mark.skipif(
     not _helper.has_cpu_queues(), reason="No CPU platforms available"
 )
-
+skip_no_level_zero = pytest.mark.skipif(
+    not _helper.has_gpu_queues("level_zero"),
+    reason="No level-zero GPU platforms available",
+)
 
 filter_strings = [
-    pytest.param("level_zero:gpu:0", marks=skip_no_gpu),
+    pytest.param("level_zero:gpu:0", marks=skip_no_level_zero),
     pytest.param("opencl:gpu:0", marks=skip_no_gpu),
     pytest.param("opencl:cpu:0", marks=skip_no_cpu),
 ]

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -25,10 +25,12 @@ from . import _helper
 from ._helper import assert_auto_offloading
 
 skip_no_gpu = pytest.mark.skipif(
-    not _helper.has_gpu_queues(), reason="No GPU platforms available"
+    not _helper.has_gpu_queues("opencl"),
+    reason="No opencl GPU platforms available",
 )
 skip_no_cpu = pytest.mark.skipif(
-    not _helper.has_cpu_queues(), reason="No CPU platforms available"
+    not _helper.has_cpu_queues("opencl"),
+    reason="No opencl CPU platforms available",
 )
 skip_no_level_zero = pytest.mark.skipif(
     not _helper.has_gpu_queues("level_zero"),


### PR DESCRIPTION
Missed check on existing device
Without level-zero:
```python
FAILED numba_dppy/tests/test_with_context.py::test_dpctl_device_context_affects_numba_pipeline[device_context0-level_zero:gpu:0] - V...
FAILED numba_dppy/tests/test_with_context.py::test_dpctl_device_context_affects_numba_pipeline[device_context1-level_zero:gpu:0] - V...
```