### PR TITLE
Use `llvm-spirv` from `dpcpp` compiler package by default

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,8 +27,8 @@ requirements:
         - numba 0.54*|0.55*
         - dpctl 0.11*
         - spirv-tools
-        - {{ compiler('dpcpp') }}  # [not osx]
         - llvm-spirv 11.*  # [osx]
+        - {{ compiler('dpcpp') }}  # [not osx]
         - dpnp 0.8*|0.9*           # [linux]
         - packaging
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
         - numba 0.54*|0.55*
         - dpctl 0.11*
         - spirv-tools
-        - llvm-spirv 11.*
+        - {{ compiler('dpcpp') }}  # [not osx]
         - dpnp 0.8*|0.9*           # [linux]
         - packaging
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
         - dpctl 0.11*
         - spirv-tools
         - {{ compiler('dpcpp') }}  # [not osx]
+        - llvm-spirv 11.*  # [osx]
         - dpnp 0.8*|0.9*           # [linux]
         - packaging
 

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -13,7 +13,7 @@ if [[ -v ONEAPI_ROOT ]]; then
     export NUMBA_DPPY_LLVM_SPIRV_ROOT="${ONEAPI_ROOT}/compiler/latest/linux/bin"
     echo "Using llvm-spirv from oneAPI"
 else
-    export NUMBA_DPPY_LLVM_SPIRV_ROOT="${CONDA_PREFIX}/bin"
+    export NUMBA_DPPY_LLVM_SPIRV_ROOT="${CONDA_PREFIX}/bin-llvm"
     echo "Using llvm-spirv from conda environment"
 fi
 

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -100,7 +100,7 @@ OFFLOAD_DIAGNOSTICS = _readenv("NUMBA_DPPY_OFFLOAD_DIAGNOSTICS", int, 0)
 FALLBACK_ON_CPU = _readenv("NUMBA_DPPY_FALLBACK_ON_CPU", int, 1)
 
 # Activate Native floating point atomcis support for supported devices.
-# Requires llvm-spirv supporting the FP atomics extensio
+# Requires llvm-spirv supporting the FP atomics extension
 NATIVE_FP_ATOMICS = _readenv("NUMBA_DPPY_ACTIVATE_ATOMICS_FP_NATIVE", int, 0)
 LLVM_SPIRV_ROOT = _readenv("NUMBA_DPPY_LLVM_SPIRV_ROOT", str, "")
 # Emit debug info

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -85,27 +85,34 @@ class CmdLine:
         if config.DEBUG:
             llvm_spirv_flags.append("--spirv-debug-info-version=ocl-100")
 
-        if config.LLVM_SPIRV_ROOT:
-            llvm_spirv_tool = shutil.which(
-                "llvm-spirv", path=config.LLVM_SPIRV_ROOT
-            )
+        llvm_spirv_tool = self._llvm_spirv()
 
-        if not llvm_spirv_tool:
+        if config.DEBUG:
+            print(f"Use llvm-spirv: {llvm_spirv_tool}")
+
+        check_call([llvm_spirv_tool, *llvm_spirv_args, "-o", opath, ipath])
+
+    @staticmethod
+    def _llvm_spirv():
+        """Return path to llvm-spirv executable."""
+        result = None
+
+        if config.LLVM_SPIRV_ROOT:
+            result = shutil.which("llvm-spirv", path=config.LLVM_SPIRV_ROOT)
+
+        if not result:
             # use llvm-spirv from dpcpp package.
             # assume dpcpp from .../bin folder.
             # assume llvm-spirv from .../bin-llvm folder.
             bin_llvm = os.path.normpath(
                 os.path.dirname(shutil.which("dpcpp")) + "/../bin-llvm/"
             )
-            llvm_spirv_tool = shutil.which("llvm-spirv", path=bin_llvm)
+            result = shutil.which("llvm-spirv", path=bin_llvm)
 
-        if not llvm_spirv_tool:
-            llvm_spirv_tool = "llvm-spirv"
+        if not result:
+            result = "llvm-spirv"
 
-        if config.DEBUG:
-            print(f"Use llvm-spirv: {llvm_spirv_tool}")
-
-        check_call([llvm_spirv_tool, *llvm_spirv_args, "-o", opath, ipath])
+        return result
 
     def link(self, opath, binaries):
         """

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -85,20 +85,21 @@ class CmdLine:
         if config.DEBUG:
             llvm_spirv_flags.append("--spirv-debug-info-version=ocl-100")
 
-        # use llvm-spirv from dpcpp package.
-        # assume dpcpp from .../bin folder.
-        # assume llvm-spirv from .../bin-llvm folder.
-        bin_llvm = os.path.normpath(
-            os.path.dirname(shutil.which("dpcpp")) + "/../bin-llvm/"
-        )
-        llvm_spirv_tool = shutil.which("llvm-spirv", path=bin_llvm)
-
         if config.LLVM_SPIRV_ROOT:
             llvm_spirv_tool = shutil.which(
                 "llvm-spirv", path=config.LLVM_SPIRV_ROOT
             )
 
-        if not os.path.exists(llvm_spirv_tool):
+        if not llvm_spirv_tool:
+            # use llvm-spirv from dpcpp package.
+            # assume dpcpp from .../bin folder.
+            # assume llvm-spirv from .../bin-llvm folder.
+            bin_llvm = os.path.normpath(
+                os.path.dirname(shutil.which("dpcpp")) + "/../bin-llvm/"
+            )
+            llvm_spirv_tool = shutil.which("llvm-spirv", path=bin_llvm)
+
+        if not llvm_spirv_tool:
             llvm_spirv_tool = "llvm-spirv"
 
         if config.DEBUG:

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -87,7 +87,7 @@ class CmdLine:
 
         # use llvm-spirv from dpcpp package.
         # assume dpcpp from .../bin folder.
-        # assume llvm-spirf from .../bin-llvm folder.
+        # assume llvm-spirv from .../bin-llvm folder.
         llvm_spirv_tool = os.path.normpath(
             os.path.dirname(shutil.which("dpcpp")) + "/../bin-llvm/llvm-spirv"
         )

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -95,6 +95,9 @@ class CmdLine:
         if config.LLVM_SPIRV_ROOT:
             llvm_spirv_tool = os.path.join(config.LLVM_SPIRV_ROOT, "llvm-spirv")
 
+        if not os.path.exists(llvm_spirv_tool):
+            llvm_spirv_tool = "llvm-spirv"
+
         check_call([llvm_spirv_tool, *llvm_spirv_args, "-o", opath, ipath])
 
     def link(self, opath, binaries):

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -86,8 +86,8 @@ class CmdLine:
             llvm_spirv_flags.append("--spirv-debug-info-version=ocl-100")
 
         # use llvm-spirv from dpcpp package.
-        # dpcpp from .../bin folder.
-        # llvm-spirf from .../bin-llvm folder.
+        # assume dpcpp from .../bin folder.
+        # assume llvm-spirf from .../bin-llvm folder.
         llvm_spirv_tool = os.path.normpath(
             os.path.dirname(shutil.which("dpcpp")) + "/../bin-llvm/llvm-spirv"
         )

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -88,12 +88,13 @@ class CmdLine:
         # use llvm-spirv from dpcpp package.
         # assume dpcpp from .../bin folder.
         # assume llvm-spirv from .../bin-llvm folder.
-        llvm_spirv_tool = os.path.normpath(
-            os.path.dirname(shutil.which("dpcpp")) + "/../bin-llvm/llvm-spirv"
+        bin_llvm = os.path.normpath(
+            os.path.dirname(shutil.which("dpcpp")) + "/../bin-llvm/"
         )
+        llvm_spirv_tool = shutil.which("llvm-spirv", path=bin_llvm)
 
         if config.LLVM_SPIRV_ROOT:
-            llvm_spirv_tool = os.path.join(config.LLVM_SPIRV_ROOT, "llvm-spirv")
+            llvm_spirv_tool = shutil.which("llvm-spirv", path=config.LLVM_SPIRV_ROOT)
 
         if not os.path.exists(llvm_spirv_tool):
             llvm_spirv_tool = "llvm-spirv"

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -94,7 +94,9 @@ class CmdLine:
         llvm_spirv_tool = shutil.which("llvm-spirv", path=bin_llvm)
 
         if config.LLVM_SPIRV_ROOT:
-            llvm_spirv_tool = shutil.which("llvm-spirv", path=config.LLVM_SPIRV_ROOT)
+            llvm_spirv_tool = shutil.which(
+                "llvm-spirv", path=config.LLVM_SPIRV_ROOT
+            )
 
         if not os.path.exists(llvm_spirv_tool):
             llvm_spirv_tool = "llvm-spirv"

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -98,6 +98,9 @@ class CmdLine:
         if not os.path.exists(llvm_spirv_tool):
             llvm_spirv_tool = "llvm-spirv"
 
+        if config.DEBUG:
+            print(f"Use llvm-spirv: {llvm_spirv_tool}")
+
         check_call([llvm_spirv_tool, *llvm_spirv_args, "-o", opath, ipath])
 
     def link(self, opath, binaries):

--- a/numba_dppy/spirv_generator.py
+++ b/numba_dppy/spirv_generator.py
@@ -15,6 +15,7 @@
 """A wrapper to connect to the SPIR-V binaries (Tools, Translator)."""
 
 import os
+import shutil
 import tempfile
 from subprocess import CalledProcessError, check_call
 
@@ -84,18 +85,15 @@ class CmdLine:
         if config.DEBUG:
             llvm_spirv_flags.append("--spirv-debug-info-version=ocl-100")
 
-        llvm_spirv_tool = "llvm-spirv"
-        if config.NATIVE_FP_ATOMICS == 1:
-            llvm_spirv_root = config.LLVM_SPIRV_ROOT
+        # use llvm-spirv from dpcpp package.
+        # dpcpp from .../bin folder.
+        # llvm-spirf from .../bin-llvm folder.
+        llvm_spirv_tool = os.path.normpath(
+            os.path.dirname(shutil.which("dpcpp")) + "/../bin-llvm/llvm-spirv"
+        )
 
-            if llvm_spirv_root == "":
-                raise ValueError(
-                    "Native floating point atomics require dpcpp provided "
-                    "llvm-spirv, please specify the LLVM-SPIRV root directory "
-                    "using env variable NUMBA_DPPY_LLVM_SPIRV_ROOT."
-                )
-
-            llvm_spirv_tool = llvm_spirv_root + "/llvm-spirv"
+        if config.LLVM_SPIRV_ROOT:
+            llvm_spirv_tool = os.path.join(config.LLVM_SPIRV_ROOT, "llvm-spirv")
 
         check_call([llvm_spirv_tool, *llvm_spirv_args, "-o", opath, ipath])
 


### PR DESCRIPTION
If `dpcpp` compiler package installed then `numba-dppy` uses `llvm-spirv` from it by default.
User could provide `LLVM_SPIRV_ROOT` to change it.

No need for defining 2 variables like here:
https://github.com/IntelPython/numba-dppy/blob/aa67724fc9a3175138264f36b034b9f8dc4a2efd/numba_dppy/examples/atomic_op.py#L33

- [x] No `llvm-spirv` package dependency
- [x] `dpcpp` package run-time dependency
- [x] Search `llvm-spirv` as `bin/dpcpp/../../bin-llvm/llvm-spirv`
- [x] Fallback to `llvm-spirv` if `dpcpp` and `LLVM_SPIRV_ROOT` don't exist
- [x] Print path to llvm-spirv for debugging 