### PR TITLE
Use `llvm-spirv` from `dpcpp` compiler package by default [cherry picked from #649]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.17.3] - 2021-11-xx
+## [0.17.3] - 2021-11-30
+
+### Changed
+* Use `llvm-spirv` from `dpcpp` compiler package by default [cherry picked from #649] (#651)
 
 ### Fixed
 * Enable offloading for `numba.njit` in `dpctl.deveice_context` (#630)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,7 +27,8 @@ requirements:
         - numba 0.54*|0.55*
         - dpctl 0.11*
         - spirv-tools
-        - llvm-spirv 11.*
+        - llvm-spirv 11.*  # [osx]
+        - {{ compiler('dpcpp') }}  # [not osx]
         - dpnp 0.8*|0.9*           # [linux]
         - packaging
 

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -13,7 +13,7 @@ if [[ -v ONEAPI_ROOT ]]; then
     export NUMBA_DPPY_LLVM_SPIRV_ROOT="${ONEAPI_ROOT}/compiler/latest/linux/bin"
     echo "Using llvm-spirv from oneAPI"
 else
-    export NUMBA_DPPY_LLVM_SPIRV_ROOT="${CONDA_PREFIX}/bin"
+    export NUMBA_DPPY_LLVM_SPIRV_ROOT="${CONDA_PREFIX}/bin-llvm"
     echo "Using llvm-spirv from conda environment"
 fi
 

--- a/numba_dppy/config.py
+++ b/numba_dppy/config.py
@@ -100,7 +100,7 @@ OFFLOAD_DIAGNOSTICS = _readenv("NUMBA_DPPY_OFFLOAD_DIAGNOSTICS", int, 0)
 FALLBACK_ON_CPU = _readenv("NUMBA_DPPY_FALLBACK_ON_CPU", int, 1)
 
 # Activate Native floating point atomcis support for supported devices.
-# Requires llvm-spirv supporting the FP atomics extensio
+# Requires llvm-spirv supporting the FP atomics extension
 NATIVE_FP_ATOMICS = _readenv("NUMBA_DPPY_ACTIVATE_ATOMICS_FP_NATIVE", int, 0)
 LLVM_SPIRV_ROOT = _readenv("NUMBA_DPPY_LLVM_SPIRV_ROOT", str, "")
 # Emit debug info


### PR DESCRIPTION
* Use llvm-spirv from dpcpp compiler package
* Fallback to llvm-spirv if dpcpp and LLVM_SPIRV_ROOT don't work
* Use llvm-spirv package for osx
* Print debug path to llvm-spirv
* Fix NUMBA_DPPY_LLVM_SPIRV_ROOT for Linux
* Add _llvm_spirv()