### PR TITLE
Reuse decorator `skip_no_opencl_Xpu` to skip tests

### DIFF
--- a/numba_dppy/tests/test_black_scholes.py
+++ b/numba_dppy/tests/test_black_scholes.py
@@ -17,11 +17,9 @@ import time
 
 import dpctl
 import numpy as np
-import pytest
 
 import numba_dppy as dppy
-
-from . import _helper
+from numba_dppy.tests._helper import skip_no_opencl_gpu
 
 RISKFREE = 0.02
 VOLATILITY = 0.30
@@ -73,9 +71,7 @@ def randfloat(rand_var, low, high):
     return (1.0 - rand_var) * low + rand_var * high
 
 
-@pytest.mark.skipif(
-    not _helper.has_opencl_gpu(), reason="test only on GPU system"
-)
+@skip_no_opencl_gpu
 class TestDPPYBlackScholes:
     def test_black_scholes(self):
         OPT_N = 400

--- a/numba_dppy/tests/test_controllable_fallback.py
+++ b/numba_dppy/tests/test_controllable_fallback.py
@@ -20,13 +20,10 @@ import numpy as np
 import pytest
 
 from numba_dppy import config
+from numba_dppy.tests._helper import skip_no_opencl_gpu
 
-from . import _helper
 
-
-@pytest.mark.skipif(
-    not _helper.has_opencl_gpu(), reason="test only on GPU system"
-)
+@skip_no_opencl_gpu
 class TestDPPYFallback:
     def test_dppy_fallback_true(self):
         @numba.jit

--- a/numba_dppy/tests/test_device_array_args.py
+++ b/numba_dppy/tests/test_device_array_args.py
@@ -15,11 +15,9 @@
 
 import dpctl
 import numpy as np
-import pytest
 
 import numba_dppy as dppy
-
-from . import _helper
+from numba_dppy.tests._helper import skip_no_opencl_cpu, skip_no_opencl_gpu
 
 
 @dppy.kernel
@@ -36,9 +34,7 @@ b = np.array(np.random.random(N), dtype=np.float32)
 d = a + b
 
 
-@pytest.mark.skipif(
-    not _helper.has_opencl_cpu(), reason="test only on CPU system"
-)
+@skip_no_opencl_cpu
 class TestDPPYDeviceArrayArgsGPU:
     def test_device_array_args_cpu(self):
         c = np.ones_like(a)
@@ -49,9 +45,7 @@ class TestDPPYDeviceArrayArgsGPU:
             assert np.all(c == d)
 
 
-@pytest.mark.skipif(
-    not _helper.has_opencl_gpu(), reason="test only on GPU system"
-)
+@skip_no_opencl_gpu
 class TestDPPYDeviceArrayArgsCPU:
     def test_device_array_args_gpu(self):
         c = np.ones_like(a)

--- a/numba_dppy/tests/test_dpnp_functions.py
+++ b/numba_dppy/tests/test_dpnp_functions.py
@@ -18,18 +18,18 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import (
     assert_auto_offloading,
     dpnp_debug,
     ensure_dpnp,
-    has_opencl_gpu,
+    skip_no_opencl_gpu,
 )
 
 
+@skip_no_opencl_gpu
 @pytest.mark.skipif(
-    not ensure_dpnp() or not has_opencl_gpu(),
-    reason="test only when dpnp and GPU is available",
+    not ensure_dpnp(),
+    reason="dpnp is not available",
 )
 class Testdpnp_functions:
     N = 10

--- a/numba_dppy/tests/test_dppy_fallback.py
+++ b/numba_dppy/tests/test_dppy_fallback.py
@@ -17,14 +17,11 @@ import warnings
 import dpctl
 import numba
 import numpy as np
-import pytest
 
-from . import _helper
+from numba_dppy.tests._helper import skip_no_opencl_gpu
 
 
-@pytest.mark.skipif(
-    not _helper.has_opencl_gpu(), reason="test only on GPU system"
-)
+@skip_no_opencl_gpu
 class TestDPPYFallback:
     def test_dppy_fallback_inner_call(self):
         @numba.jit

--- a/numba_dppy/tests/test_dppy_func.py
+++ b/numba_dppy/tests/test_dppy_func.py
@@ -14,16 +14,12 @@
 
 import dpctl
 import numpy as np
-import pytest
 
 import numba_dppy as dppy
+from numba_dppy.tests._helper import skip_no_opencl_gpu
 
-from . import _helper
 
-
-@pytest.mark.skipif(
-    not _helper.has_opencl_gpu(), reason="test only on GPU system"
-)
+@skip_no_opencl_gpu
 class TestDPPYFunc:
     N = 257
 

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -22,6 +22,7 @@ from numba.core.registry import cpu_target
 
 import numba_dppy as dppy
 from numba_dppy.compiler import DPPYCompiler
+from numba_dppy.tests._helper import skip_no_opencl_gpu
 
 
 def fn(a):
@@ -30,6 +31,7 @@ def fn(a):
     return a
 
 
+@skip_no_opencl_gpu
 def test_no_copy_usm_shared(capfd):
     a = usmarray.ones(10, dtype=np.int64)
     b = np.ones(10, dtype=np.int64)
@@ -45,10 +47,7 @@ def test_no_copy_usm_shared(capfd):
     targetctx = cpu_target.target_context
     args = typingctx.resolve_argument_type(a)
 
-    try:
-        device = dpctl.SyclDevice("opencl:gpu:0")
-    except ValueError:
-        pytest.skip("Device not found")
+    device = dpctl.SyclDevice("opencl:gpu:0")
 
     with dpctl.device_context(device):
         cres = compiler.compile_extra(

--- a/numba_dppy/tests/test_offload_diagnostics.py
+++ b/numba_dppy/tests/test_offload_diagnostics.py
@@ -14,19 +14,15 @@
 
 import dpctl
 import numpy as np
-import pytest
 from numba import njit, prange
 from numba.tests.support import captured_stdout
 
 import numba_dppy as dppy
 from numba_dppy import config as dppy_config
+from numba_dppy.tests._helper import skip_no_opencl_gpu
 
-from . import _helper
 
-
-@pytest.mark.skipif(
-    not _helper.has_opencl_gpu(), reason="test only on GPU system"
-)
+@skip_no_opencl_gpu
 class TestOffloadDiagnostics:
     def test_parfor(self):
         def prange_func():

--- a/numba_dppy/tests/test_parfor_lower_message.py
+++ b/numba_dppy/tests/test_parfor_lower_message.py
@@ -14,14 +14,11 @@
 
 import dpctl
 import numpy as np
-import pytest
 from numba import njit, prange
 from numba.tests.support import captured_stdout
 
-import numba_dppy as dppy
 from numba_dppy import config
-
-from . import _helper
+from numba_dppy.tests._helper import skip_no_opencl_gpu
 
 
 def prange_example():
@@ -35,9 +32,7 @@ def prange_example():
     return a
 
 
-@pytest.mark.skipif(
-    not _helper.has_opencl_gpu(), reason="test only on GPU system"
-)
+@skip_no_opencl_gpu
 class TestParforMessage:
     def test_parfor_message(self):
         device = dpctl.SyclDevice("opencl:gpu")

--- a/numba_dppy/tests/test_prange.py
+++ b/numba_dppy/tests/test_prange.py
@@ -19,14 +19,10 @@ import pytest
 from numba import njit, prange
 
 import numba_dppy as dppy
-from numba_dppy.tests._helper import assert_auto_offloading
-
-from . import _helper
+from numba_dppy.tests._helper import assert_auto_offloading, skip_no_opencl_gpu
 
 
-@pytest.mark.skipif(
-    not _helper.has_opencl_gpu(), reason="test only on GPU system"
-)
+@skip_no_opencl_gpu
 class TestPrange:
     def test_one_prange(self):
         @njit

--- a/numba_dppy/tests/test_sum_reduction.py
+++ b/numba_dppy/tests/test_sum_reduction.py
@@ -16,11 +16,9 @@ import math
 
 import dpctl
 import numpy as np
-import pytest
 
 import numba_dppy as dppy
-
-from . import _helper
+from numba_dppy.tests._helper import skip_no_opencl_gpu
 
 
 @dppy.kernel
@@ -32,9 +30,7 @@ def reduction_kernel(A, R, stride):
     A[i] = R[i]
 
 
-@pytest.mark.skipif(
-    not _helper.has_opencl_gpu(), reason="test only on GPU system"
-)
+@skip_no_opencl_gpu
 class TestDPPYSumReduction:
     def test_sum_reduction(self):
         # This test will only work for even case

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -21,8 +21,12 @@ from numba.tests.support import captured_stdout
 import numba_dppy as dppy
 from numba_dppy import config
 
-from . import _helper
-from ._helper import assert_auto_offloading, filter_strings
+from ._helper import (
+    assert_auto_offloading,
+    filter_strings,
+    skip_no_opencl_cpu,
+    skip_no_opencl_gpu,
+)
 
 
 def scenario(filter_str, context):
@@ -52,9 +56,7 @@ def test_dpctl_device_context_affects_numba_pipeline(filter_str, context):
 
 
 class TestWithDPPYContext:
-    @pytest.mark.skipif(
-        not _helper.has_opencl_gpu(), reason="No GPU platforms available"
-    )
+    @skip_no_opencl_gpu
     def test_with_dppy_context_gpu(self):
         @njit
         def nested_func(a, b):
@@ -80,9 +82,7 @@ class TestWithDPPYContext:
         np.testing.assert_array_equal(expected, got_gpu)
         assert "Parfor offloaded to opencl:gpu" in got_gpu_message.getvalue()
 
-    @pytest.mark.skipif(
-        not _helper.has_opencl_cpu(), reason="No CPU platforms available"
-    )
+    @skip_no_opencl_cpu
     def test_with_dppy_context_cpu(self):
         @njit
         def nested_func(a, b):


### PR DESCRIPTION
Part of https://github.com/IntelPython/numba-dppy/pull/657