### PR TITLE
Fix building with DPNP

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -127,7 +127,7 @@ jobs:
         integration_channels: [""]
         experimental: [false]
         artifact_name: [""]
-        dependencies: ["mkl=2021.3.0"]  # dpnp dependency
+        dependencies: [""]
         include:
           - python: "3.8"
             numba: 0.54
@@ -135,21 +135,21 @@ jobs:
             integration_channels: -c dppy/label/dev
             artifact_name: -c dppy_label_dev
             experimental: false  # current stable
-            dependencies: "mkl=2021.3.0"  # dpnp dependency
+            dependencies: ""
           - python: "3.8"
             numba: "0.55.0dev0=*_782"
             dpctl: "0.12"
             integration_channels:
             artifact_name: ""
             experimental: false  # current stable
-            dependencies: "mkl=2021.3.0"  # dpnp dependency
+            dependencies: ""
           - python: "3.9"
             numba: "0.55.0dev0=*_778"
             dpctl: "0.12"
             integration_channels: ""
             artifact_name: ""
             experimental: false  # current stable
-            dependencies: "mkl=2021.3.0"  # dpnp dependency
+            dependencies: ""
     continue-on-error: ${{ matrix.experimental }}
     env:
       # conda-forge: llvm-spirv 11 not on intel channel yet

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -3,6 +3,9 @@
 @REM used BUILD_PREFIX as compiler installed in build section of meta.yml
 set "PATH=%BUILD_PREFIX%\Library\bin-llvm;%PATH%"
 
+@REM DPNP is not available on Windows, it allows building w/o DPNP
+set NUMBA_DPPY_BUILD_SKIP_NO_DPNP=1
+
 %PYTHON% setup.py install --single-version-externally-managed --record=record.txt
 
 rem Build wheel package

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -7,3 +7,9 @@ cxx_compiler_version:       # [linux]
 
 dpctl:
   - 0.11.0
+
+mkl:
+  - 2021.3.0
+
+pin_run_as_build:
+  mkl: x.x

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
         - numba 0.54*|0.55*
         - dpctl {{ dpctl }}
         - dpnp 0.8*|0.9*           # [linux]
+        - mkl {{ mkl }}            # [linux]
         - wheel
     run:
         - python
@@ -29,6 +30,7 @@ requirements:
         - spirv-tools
         - llvm-spirv 11.*
         - dpnp 0.8*|0.9*           # [linux]
+        - mkl                      # [linux]
         - packaging
 
 test:

--- a/numba_dppy/tests/test_dpnp_iface.py
+++ b/numba_dppy/tests/test_dpnp_iface.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+dpnp = pytest.importorskip("dpnp")
+
+
+def test_import_dpnp():
+    """Test that import dpnp works"""
+    import dpnp
+
+
+def test_import_dpnp_fptr_interface():
+    """Test that we can import dpnp_fptr_interface if dpnp is installed"""
+    from numba_dppy.dpnp_iface import dpnp_fptr_interface

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,15 @@ elif sys.platform in ["win32", "cygwin"]:
 def get_ext_modules():
     ext_modules = []
 
-    dpnp_present = False
     try:
         import dpnp
-    except:
-        pass
-    else:
+
         dpnp_present = True
+    except ImportError:
+        if int(os.environ.get("NUMBA_DPPY_BUILD_SKIP_NO_DPNP", 0)):
+            dpnp_present = False
+        else:
+            raise ImportError("DPNP is not available")
 
     import dpctl
     import numba


### PR DESCRIPTION
Even if `dpnp` could be imported then importing `dpnp_fptr_interface` could fail.
`dpnp_fptr_interface` module could absent in conda package if `dpnp` was not imported during building.
`dpnp` could be not imported during building if wrong version of `mkl` was installed. 
`dpnp` package should pin correct version of `mkl`.

- [x] Added test for check importing `dpnp` and `dpnp_fptr_interface`
- [x] Eliminate silent skipping `dpnp` during building
- [x] Configured build on Windows to skip if `dpnp` is not available
- [x] now `numba-dppy` pins version of `mkl` compatible with `dpnp 0.9.0dev0_58` from `dppy/lable/dev`. It should be in `dpnp` itself. 
- [x] Reverts pinning in workflow made in #648.