### PR TITLE
Pin dpctl 0.11.4 [public CI]

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -123,7 +123,7 @@ jobs:
       matrix:
         python: ["3.8", "3.9"]
         numba: ["0.54"]
-        dpctl: ["0.11", "0.12"]
+        dpctl: ["0.11.4", "0.12"]
         dpnp: ["0.9.0dev0"]
         integration_channels: [""]
         experimental: [false]


### PR DESCRIPTION
New packages on `-c intel` was published. Now `dpctl 0.11.1 -c intel` is used for testing. It does not work with `dpcpp-cpp-rt 2021.3.0`.
`dpctl 0.11.1` does not control dependency on `dpcpp-cpp-rt` - https://github.com/IntelPython/dpctl/issues/727.
This PR makes testing w/ `dpctl 0.11.4` which is from `-c dppy/label/dev` and can work w/ `dpcpp-cpp-rt 2021.3.0`.
It is temporary solution.