### PR TITLE
Load dpctl lib on Linux using `libDPCTLSyclInterface.so.0`

### DIFF
--- a/numba_dppy/initialize.py
+++ b/numba_dppy/initialize.py
@@ -52,7 +52,7 @@ def load_dpctl_sycl_interface():
     else:
         paths = glob.glob(
             os.path.join(
-                os.path.dirname(dpctl.__file__), "*DPCTLSyclInterface.so"
+                os.path.dirname(dpctl.__file__), "*DPCTLSyclInterface.so.0"
             )
         )
 


### PR DESCRIPTION
Fixes #700.
Issue in dpctl: https://github.com/IntelPython/dpctl/issues/777