### PR TITLE
Support for coverage in internal CI

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
 test:
   requires:
     - pytest
+    - pytest-cov
     - {{ compiler('dpcpp') }}  # [not osx]
     - pexpect
 


### PR DESCRIPTION
This PR adds `pytest-cov` requirement to test section of conda recipe for support coverege in internal CI. 