### PR TITLE
Search `llvm-spirv` for `setup.py` in folder `bin-llvm`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,13 +125,35 @@ def spirv_compile():
         "numba_dppy/ocl/atomics/atomic_ops.bc",
     ]
     spirv_args = [
-        "llvm-spirv",
+        _llvm_spirv(),
         "-o",
         "numba_dppy/ocl/atomics/atomic_ops.spir",
         "numba_dppy/ocl/atomics/atomic_ops.bc",
     ]
     subprocess.check_call(clang_args, stderr=subprocess.STDOUT, shell=False)
     subprocess.check_call(spirv_args, stderr=subprocess.STDOUT, shell=False)
+
+
+def _llvm_spirv():
+    """Return path to llvm-spirv executable."""
+    import shutil
+
+    result = None
+
+    if result is None:
+        # use llvm-spirv from dpcpp package.
+        # assume dpcpp from .../bin folder.
+        # assume llvm-spirv from .../bin-llvm folder.
+        dpcpp_path = shutil.which("dpcpp")
+        if dpcpp_path is not None:
+            bin_llvm = os.path.dirname(dpcpp_path) + "/../bin-llvm/"
+            bin_llvm = os.path.normpath(bin_llvm)
+            result = shutil.which("llvm-spirv", path=bin_llvm)
+
+    if result is None:
+        result = "llvm-spirv"
+
+    return result
 
 
 packages = find_packages(include=["numba_dppy", "numba_dppy.*"])


### PR DESCRIPTION
Previously you had to add `bin-llvm` to `PATH`: `export PATH=$CONDA_PREFIX/bin-llvm:$PATH`. See `conda-recipe`.
Now `setup.py` can find `llvm-spirv` using path to `dpcpp`.