### PR TITLE
Remove DPPY prefix for modules and functions in numba_dppy.core.passes.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,4 +18,4 @@ exclude =
     __pycache__,
     _version.py,
     numpy_usm_shared.py,
-    dppy_lowerer.py,
+    lowerer.py,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
     -   id: isort
         name: isort (python)
-        exclude: "dppy_lowerer.py"
+        exclude: "lowerer.py"
     -   id: isort
         name: isort (cython)
         types: [cython]

--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -45,7 +45,7 @@ from numba_dppy.utils import (
 )
 
 from . import spirv_generator
-from .dppy_passbuilder import DPPYPassBuilder
+from .dppy_passbuilder import PassBuilder
 
 _NUMBA_DPPY_READ_ONLY = "read_only"
 _NUMBA_DPPY_WRITE_ONLY = "write_only"
@@ -101,7 +101,7 @@ class DPPYCompiler(CompilerBase):
         ] = self.state.parfor_diagnostics
         if not self.state.flags.force_pyobject:
             # print("Numba-DPPY [INFO]: Using Numba-DPPY pipeline")
-            pms.append(DPPYPassBuilder.define_nopython_pipeline(self.state))
+            pms.append(PassBuilder.define_nopython_pipeline(self.state))
         if self.state.status.can_fallback or self.state.flags.force_pyobject:
             pms.append(
                 DefaultPassBuilder.define_objectmode_pipeline(self.state)

--- a/numba_dppy/core/passes/lowerer.py
+++ b/numba_dppy/core/passes/lowerer.py
@@ -1264,7 +1264,7 @@ class WrapperDefaultLower(Lower):
         return True
 
 
-class DPPYLower(Lower):
+class DPEXLowerer(Lower):
     def __init__(self, context, library, fndesc, func_ir, metadata=None):
         Lower.__init__(self, context, library, fndesc, func_ir, metadata)
         memo = {}

--- a/numba_dppy/core/passes/passes.py
+++ b/numba_dppy/core/passes/passes.py
@@ -41,13 +41,13 @@ from numba.parfors.parfor import swap_functions_map
 
 from numba_dppy import config
 
-from .dppy_lowerer import DPPYLower
+from .lowerer import DPEXLowerer
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)
-class DPPYConstantSizeStaticLocalMemoryPass(FunctionPass):
+class ConstantSizeStaticLocalMemoryPass(FunctionPass):
 
-    _name = "dppy_constant_size_static_local_memory_pass"
+    _name = "dpex_constant_size_static_local_memory_pass"
 
     def __init__(self):
         FunctionPass.__init__(self)
@@ -64,9 +64,8 @@ class DPPYConstantSizeStaticLocalMemoryPass(FunctionPass):
 
         if _DEBUG:
             print(
-                "Checks if size of OpenCL local address space alloca is a compile-time constant.".center(
-                    80, "-"
-                )
+                "Checks if size of OpenCL local address space alloca is a "
+                + "compile-time constant.".center(80, "-")
             )
             print(func_ir.dump())
 
@@ -99,7 +98,8 @@ class DPPYConstantSizeStaticLocalMemoryPass(FunctionPass):
                                     ):
 
                                         arg = None
-                                        # at first look in keyword arguments to get the shape, which has to be
+                                        # at first look in keyword arguments to
+                                        # get the shape, which has to be
                                         # constant
                                         if expr.kws:
                                             for _arg in expr.kws:
@@ -110,7 +110,8 @@ class DPPYConstantSizeStaticLocalMemoryPass(FunctionPass):
                                             arg = expr.args[0]
 
                                         error = False
-                                        # arg can be one constant or a tuple of constant items
+                                        # arg can be one constant or a tuple of
+                                        # constant items
                                         arg_type = func_ir.get_definition(
                                             arg.name
                                         )
@@ -138,7 +139,8 @@ class DPPYConstantSizeStaticLocalMemoryPass(FunctionPass):
 
                                         if error:
                                             warnings.warn_explicit(
-                                                "The size of the Local memory has to be constant",
+                                                "The size of the Local memory "
+                                                + "has to be constant",
                                                 errors.NumbaError,
                                                 state.func_id.filename,
                                                 state.func_id.firstlineno,
@@ -154,9 +156,9 @@ class DPPYConstantSizeStaticLocalMemoryPass(FunctionPass):
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)
-class DPPYPreParforPass(FunctionPass):
+class PreParforPass(FunctionPass):
 
-    _name = "dppy_pre_parfor_pass"
+    _name = "dpex_pre_parfor_pass"
 
     def __init__(self):
         FunctionPass.__init__(self)
@@ -200,9 +202,9 @@ class DPPYPreParforPass(FunctionPass):
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)
-class DPPYParforPass(FunctionPass):
+class ParforPass(FunctionPass):
 
-    _name = "dppy_parfor_pass"
+    _name = "dpex_parfor_pass"
 
     def __init__(self):
         FunctionPass.__init__(self)
@@ -267,9 +269,9 @@ def fallback_context(state, msg):
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)
-class SpirvFriendlyLowering(LoweringPass):
+class DPEXLowering(LoweringPass):
 
-    _name = "spirv_friendly_lowering"
+    _name = "dpex_lowering"
 
     def __init__(self):
         LoweringPass.__init__(self)
@@ -317,7 +319,7 @@ class SpirvFriendlyLowering(LoweringPass):
             )
 
             with targetctx.push_code_library(library):
-                lower = DPPYLower(
+                lower = DPEXLowerer(
                     targetctx, library, fndesc, interp, metadata=metadata
                 )
                 lower.lower()
@@ -348,9 +350,9 @@ class SpirvFriendlyLowering(LoweringPass):
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)
-class DPPYNoPythonBackend(FunctionPass):
+class NoPythonBackend(FunctionPass):
 
-    _name = "nopython_backend"
+    _name = "dpex_nopython_backend"
 
     def __init__(self):
         FunctionPass.__init__(self)
@@ -388,15 +390,15 @@ class DPPYNoPythonBackend(FunctionPass):
 
 
 @register_pass(mutates_CFG=False, analysis_only=True)
-class DPPYDumpParforDiagnostics(AnalysisPass):
+class DumpParforDiagnostics(AnalysisPass):
 
-    _name = "dump_parfor_diagnostics"
+    _name = "dpex_dump_parfor_diagnostics"
 
     def __init__(self):
         AnalysisPass.__init__(self)
 
     def run_pass(self, state):
-        # if state.flags.auto_parallel.enabled: //add in condition flag for kernels
+        # if state.flags.auto_parallel.enabled, add a condition flag for kernels
         if config.OFFLOAD_DIAGNOSTICS:
             if state.parfor_diagnostics is not None:
                 state.parfor_diagnostics.dump(config.PARALLEL_DIAGNOSTICS)


### PR DESCRIPTION
In preparation for the renaming from numba_dppy to numba_dpex, the PR renames the modules `dppy_lowerer` and `dppy_passes` to just `lowerer` and `passes`. The goal is to reduce the usage of `DPPY` or `numba_dppy` prefixes as much as possible to easy the name change.