### PR TITLE
Rename/array type

### DIFF
--- a/numba_dppy/compiler.py
+++ b/numba_dppy/compiler.py
@@ -28,9 +28,9 @@ from numba.core.compiler_lock import global_compiler_lock
 from numba.core.typing.templates import AbstractTemplate, ConcreteTemplate
 
 from numba_dppy import config
+from numba_dppy.core.types import Array
 from numba_dppy.dpctl_iface import USMNdArrayType
 from numba_dppy.dpctl_support import dpctl_version
-from numba_dppy.dppy_array_type import DPPYArray
 from numba_dppy.parfor_diagnostics import ExtendedParforDiagnostics
 from numba_dppy.utils import (
     IndeterminateExecutionQueueError,
@@ -183,11 +183,9 @@ def compile_with_depx(pyfunc, return_type, args, is_kernel, debug=None):
 
 
 def compile_kernel(sycl_queue, pyfunc, args, access_types, debug=None):
-    # For any array we only accept numba_dpex.dppy_array_type.DPPYArray
+    # For any array we only accept numba_dpex.types.Array
     for arg in args:
-        if isinstance(arg, types.npytypes.Array) and not isinstance(
-            arg, DPPYArray
-        ):
+        if isinstance(arg, types.npytypes.Array) and not isinstance(arg, Array):
             raise TypeError(
                 "We only accept DPPYArray as type of array-like objects. We received %s"
                 % (type(arg))
@@ -224,14 +222,12 @@ def compile_kernel(sycl_queue, pyfunc, args, access_types, debug=None):
 def compile_kernel_parfor(
     sycl_queue, func_ir, args, args_with_addrspaces, debug=None
 ):
-    # For any array we only accept numba_dpex.dppy_array_type.DPPYArray
+    # We only accept numba_dpex.core.types.Array type
     for arg in args_with_addrspaces:
-        if isinstance(arg, types.npytypes.Array) and not isinstance(
-            arg, DPPYArray
-        ):
+        if isinstance(arg, types.npytypes.Array) and not isinstance(arg, Array):
             raise TypeError(
-                "We only accept DPPYArray as type of array-like objects. We received %s"
-                % (type(arg))
+                "Only numba_dpex.core.types.Array objects are supported as "
+                + "kernel arguments. Received %s" % (type(arg))
             )
     if config.DEBUG:
         print("compile_kernel_parfor", args)
@@ -792,8 +788,9 @@ class JitKernel(KernelBase):
                         queue = memory.sycl_queue
                     queues.append(queue)
 
-            # dpctl.utils.get_exeuction_queue() checks if the queues passed are equivalent and returns a
-            # SYCL queue if they are equivalent and None if they are not.
+            # dpctl.utils.get_exeuction_queue() checks if the queues passed are
+            # equivalent and returns a SYCL queue if they are equivalent and
+            # None if they are not.
             compute_queue = dpctl.utils.get_execution_queue(queues)
             if compute_queue is None:
                 raise IndeterminateExecutionQueueError(

--- a/numba_dppy/core/passes/lowerer.py
+++ b/numba_dppy/core/passes/lowerer.py
@@ -55,9 +55,9 @@ from numba.parfors.parfor_lowering import _lower_parfor_parallel
 import numba_dppy as dppy
 from numba_dppy import config
 from numba_dppy.dpctl_iface import KernelLaunchOps
-from numba_dppy.dppy_array_type import DPPYArray
+from numba_dppy.core.types import Array
 from numba_dppy.target import DpexTargetContext
-from numba_dppy.utils import address_space, npytypes_array_to_dppy_array
+from numba_dppy.utils import address_space, npytypes_array_to_dpex_array
 
 from .dufunc_inliner import dufunc_inliner
 
@@ -416,7 +416,7 @@ def _create_gufunc_for_parfor_body(
             # Convert Numba's npytype.Array to DPPYArray data type. DPPYArray
             # allows us to specify an address space for the data and other
             # pointer arguments for the array.
-            param_types_addrspaces[i] = npytypes_array_to_dppy_array(
+            param_types_addrspaces[i] = npytypes_array_to_dpex_array(
                 param_types_addrspaces[i], addrspaces[i]
             )
 

--- a/numba_dppy/core/types/__init__.py
+++ b/numba_dppy/core/types/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .array_type import *

--- a/numba_dppy/core/types/array_type.py
+++ b/numba_dppy/core/types/array_type.py
@@ -18,9 +18,9 @@ from numba.core.datamodel.models import StructModel
 from numba.core.types.npytypes import Array
 
 
-class DPPYArray(Array):
+class Array(Array):
     """
-    Type class for DPPY arrays.
+    An array type for use inside our compiler pipeline.
     """
 
     def __init__(
@@ -34,7 +34,7 @@ class DPPYArray(Array):
         addrspace=None,
     ):
         self.addrspace = addrspace
-        super(DPPYArray, self).__init__(
+        super(Array, self).__init__(
             dtype,
             ndim,
             layout,
@@ -56,7 +56,7 @@ class DPPYArray(Array):
             readonly = not self.mutable
         if addrspace is None:
             addrspace = self.addrspace
-        return DPPYArray(
+        return Array(
             dtype=dtype,
             ndim=ndim,
             layout=layout,
@@ -84,7 +84,7 @@ class DPPYArray(Array):
         return self.dtype.is_precise()
 
 
-class DPPYArrayModel(StructModel):
+class ArrayModel(StructModel):
     def __init__(self, dmm, fe_type):
         ndim = fe_type.ndim
         members = [
@@ -105,4 +105,4 @@ class DPPYArrayModel(StructModel):
             ("shape", types.UniTuple(types.intp, ndim)),
             ("strides", types.UniTuple(types.intp, ndim)),
         ]
-        super(DPPYArrayModel, self).__init__(dmm, fe_type, members)
+        super(ArrayModel, self).__init__(dmm, fe_type, members)

--- a/numba_dppy/decorators.py
+++ b/numba_dppy/decorators.py
@@ -15,7 +15,7 @@
 import dpctl
 from numba.core import sigutils, types
 
-from numba_dppy.utils import assert_no_return, npytypes_array_to_dppy_array
+from numba_dppy.utils import assert_no_return, npytypes_array_to_dpex_array
 
 from .compiler import (
     JitKernel,
@@ -54,7 +54,7 @@ def _kernel_jit(signature, debug, access_types):
     argtypes, rettype = sigutils.normalize_signature(signature)
     argtypes = tuple(
         [
-            npytypes_array_to_dppy_array(ty)
+            npytypes_array_to_dpex_array(ty)
             if isinstance(ty, types.npytypes.Array)
             else ty
             for ty in argtypes
@@ -93,7 +93,7 @@ def _func_jit(signature, debug=None):
     argtypes, restype = sigutils.normalize_signature(signature)
     argtypes = tuple(
         [
-            npytypes_array_to_dppy_array(ty)
+            npytypes_array_to_dpex_array(ty)
             if isinstance(ty, types.npytypes.Array)
             else ty
             for ty in argtypes

--- a/numba_dppy/dpctl_iface/usm_ndarray_type.py
+++ b/numba_dppy/dpctl_iface/usm_ndarray_type.py
@@ -16,12 +16,12 @@ from dpctl.tensor import usm_ndarray
 from numba.extending import register_model, typeof_impl
 from numba.np import numpy_support
 
-import numba_dppy.target as dppy_target
-from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
+import numba_dppy.target as dpex_target
+from numba_dppy.core.types import Array, ArrayModel
 from numba_dppy.utils import address_space
 
 
-class USMNdArrayType(DPPYArray):
+class USMNdArrayType(Array):
     """
     USMNdArrayType(dtype, ndim, layout, usm_type,
                     readonly=False, name=None,
@@ -57,8 +57,8 @@ class USMNdArrayType(DPPYArray):
 
 
 # This tells Numba to use the DPPYArray data layout for object of type USMNdArrayType.
-register_model(USMNdArrayType)(DPPYArrayModel)
-dppy_target.spirv_data_model_manager.register(USMNdArrayType, DPPYArrayModel)
+register_model(USMNdArrayType)(ArrayModel)
+dpex_target.spirv_data_model_manager.register(USMNdArrayType, ArrayModel)
 
 
 @typeof_impl.register(usm_ndarray)

--- a/numba_dppy/dpnp_ndarray/types.py
+++ b/numba_dppy/dpnp_ndarray/types.py
@@ -15,10 +15,10 @@
 from dpnp import ndarray
 from numba.core import types
 
-from numba_dppy.dppy_array_type import DPPYArray
+from numba_dppy.core.types import Array
 
 
-class dpnp_ndarray_Type(DPPYArray):
+class dpnp_ndarray_Type(Array):
     """Numba type for dpnp.ndarray."""
 
     def __init__(

--- a/numba_dppy/numpy_usm_shared.py
+++ b/numba_dppy/numpy_usm_shared.py
@@ -58,9 +58,9 @@ from numba.extending import (
 from numba.np import numpy_support
 from numba.np.arrayobj import _array_copy
 
-from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
+from numba_dppy.core.types import Array, ArrayModel
 
-from . import target as dppy_target
+from . import target as dpex_target
 
 debug = config.DEBUG
 
@@ -84,7 +84,7 @@ for (
     llb.add_symbol(py_name, c_address)
 
 
-class UsmSharedArrayType(DPPYArray):
+class UsmSharedArrayType(Array):
     """Creates a Numba type for Numpy arrays that are stored in USM shared
     memory.  We inherit from Numba's existing Numpy array type but overload
     how this type is printed during dumping of typing information and we
@@ -161,7 +161,7 @@ def typeof_ta_ndarray(val, c):
 # register_model(UsmSharedArrayType)(DPPYArrayModel)
 register_model(UsmSharedArrayType)(numba.core.datamodel.models.ArrayModel)
 # dppy_target.spirv_data_model_manager.register(UsmSharedArrayType, DPPYArrayModel)
-dppy_target.spirv_data_model_manager.register(
+dpex_target.spirv_data_model_manager.register(
     UsmSharedArrayType, numba.core.datamodel.models.ArrayModel
 )
 

--- a/numba_dppy/ocl/ocldecl.py
+++ b/numba_dppy/ocl/ocldecl.py
@@ -24,7 +24,7 @@ from numba.core.typing.templates import (
 )
 
 import numba_dppy as dppy
-from numba_dppy.dppy_array_type import DPPYArray
+from numba_dppy.core.types import Array
 from numba_dppy.utils import address_space
 
 registry = Registry()
@@ -167,7 +167,7 @@ class OCL_local_array(CallableTemplate):
             ndim = parse_shape(shape)
             nb_dtype = parse_dtype(dtype)
             if nb_dtype is not None and ndim is not None:
-                return DPPYArray(
+                return Array(
                     dtype=nb_dtype,
                     ndim=ndim,
                     layout="C",
@@ -211,7 +211,7 @@ class OCL_private_array(CallableTemplate):
             ndim = parse_shape(shape)
             nb_dtype = parse_dtype(dtype)
             if nb_dtype is not None and ndim is not None:
-                return DPPYArray(
+                return Array(
                     dtype=nb_dtype,
                     ndim=ndim,
                     layout="C",

--- a/numba_dppy/ocl/oclimpl.py
+++ b/numba_dppy/ocl/oclimpl.py
@@ -27,7 +27,7 @@ from numba.core.typing.npydecl import parse_dtype
 
 from numba_dppy import config, target
 from numba_dppy.codegen import SPIR_DATA_LAYOUT
-from numba_dppy.dppy_array_type import DPPYArray
+from numba_dppy.core.types import Array
 from numba_dppy.ocl.atomics import atomic_helper
 from numba_dppy.utils import address_space
 
@@ -433,10 +433,7 @@ def atomic_add(context, builder, sig, args, name):
         lary = context.make_array(aryty)(context, builder, ary)
         ptr = cgutils.get_item_pointer(context, builder, aryty, lary, indices)
 
-        if (
-            isinstance(aryty, DPPYArray)
-            and aryty.addrspace == address_space.LOCAL
-        ):
+        if isinstance(aryty, Array) and aryty.addrspace == address_space.LOCAL:
             return insert_and_call_atomic_fn(
                 context,
                 builder,
@@ -572,7 +569,7 @@ def _make_array(
 ):
     ndim = len(shape)
     # Create array object
-    aryty = DPPYArray(dtype=dtype, ndim=ndim, layout="C", addrspace=addrspace)
+    aryty = Array(dtype=dtype, ndim=ndim, layout="C", addrspace=addrspace)
     ary = context.make_array(aryty)(context, builder)
 
     targetdata = _get_target_data(context)

--- a/numba_dppy/target.py
+++ b/numba_dppy/target.py
@@ -26,13 +26,13 @@ from numba.core.registry import cpu_target
 from numba.core.target_extension import GPU, target_registry
 from numba.core.utils import cached_property
 
-from numba_dppy.dppy_array_type import DPPYArray, DPPYArrayModel
+from numba_dppy.core.types import Array, ArrayModel
 from numba_dppy.utils import (
     address_space,
     calling_conv,
     has_usm_memory,
-    npytypes_array_to_dppy_array,
-    suai_to_dppy_array_type,
+    npytypes_array_to_dpex_array,
+    suai_to_dpex_array,
 )
 
 from . import codegen
@@ -52,7 +52,7 @@ class DpexTypingContext(typing.BaseContext):
     Numba's ``typing.BaseContext`` class. We add two specific functionalities to
     the basic Numba typing context features: An overridden
     :func:`resolve_argument_type` that changes all ``npytypes.Array`` to
-    :class:`dppy_array_type.DppyArray`. An overridden
+    :class:`numba_depx.core.types.Array`. An overridden
     :func:`load_additional_registries` that registers OpenCL math and other
     functions to the typing context.
 
@@ -85,11 +85,11 @@ class DpexTypingContext(typing.BaseContext):
             # we create the necessary Numba type to represent it
             # and send it back.
             if has_usm_memory(val) is not None:
-                return suai_to_dppy_array_type(val)
+                return suai_to_dpex_array(val)
 
         if _type is types.npytypes.Array:
             # Convert npytypes.Array to DPPYArray
-            return npytypes_array_to_dppy_array(typeof(val))
+            return npytypes_array_to_dpex_array(typeof(val))
         else:
             return super().resolve_argument_type(val)
 
@@ -119,7 +119,7 @@ class GenericPointerModel(datamodel.PrimitiveModel):
 def _init_data_model_manager():
     dmm = datamodel.default_manager.copy()
     dmm.register(types.CPointer, GenericPointerModel)
-    dmm.register(DPPYArray, DPPYArrayModel)
+    dmm.register(Array, ArrayModel)
     return dmm
 
 

--- a/numba_dppy/tests/test_debuginfo.py
+++ b/numba_dppy/tests/test_debuginfo.py
@@ -22,7 +22,7 @@ from numba.core import types
 import numba_dppy as dppy
 from numba_dppy import compiler
 from numba_dppy.tests._helper import override_config
-from numba_dppy.utils import npytypes_array_to_dppy_array
+from numba_dppy.utils import npytypes_array_to_dpex_array
 
 debug_options = [True, False]
 
@@ -91,9 +91,9 @@ def test_debug_info_locals_vars_on_no_opt():
 
     sycl_queue = dpctl.get_current_queue()
     sig = (
-        npytypes_array_to_dppy_array(types.float32[:]),
-        npytypes_array_to_dppy_array(types.float32[:]),
-        npytypes_array_to_dppy_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
     )
 
     with override_config("OPT", 0):
@@ -120,7 +120,7 @@ def test_debug_kernel_local_vars_in_ir():
     ]
 
     sycl_queue = dpctl.get_current_queue()
-    sig = (npytypes_array_to_dppy_array(types.float32[:]),)
+    sig = (npytypes_array_to_dpex_array(types.float32[:]),)
 
     kernel_ir = get_kernel_ir(sycl_queue, foo, sig, debug=True)
 
@@ -150,9 +150,9 @@ def test_debug_flag_generates_ir_with_debuginfo_for_func(debug_option):
 
     sycl_queue = dpctl.get_current_queue()
     sig = (
-        npytypes_array_to_dppy_array(types.float32[:]),
-        npytypes_array_to_dppy_array(types.float32[:]),
-        npytypes_array_to_dppy_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
     )
 
     kernel_ir = get_kernel_ir(
@@ -185,9 +185,9 @@ def test_env_var_generates_ir_with_debuginfo_for_func(debug_option):
 
     sycl_queue = dpctl.get_current_queue()
     sig = (
-        npytypes_array_to_dppy_array(types.float32[:]),
-        npytypes_array_to_dppy_array(types.float32[:]),
-        npytypes_array_to_dppy_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
     )
 
     with override_config("DEBUGINFO_DEFAULT", int(debug_option)):
@@ -209,8 +209,8 @@ def test_debuginfo_DISubprogram_linkageName():
 
     sycl_queue = dpctl.get_current_queue()
     sig = (
-        npytypes_array_to_dppy_array(types.float32[:]),
-        npytypes_array_to_dppy_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
     )
 
     kernel_ir = get_kernel_ir(sycl_queue, func, sig, debug=True)
@@ -232,8 +232,8 @@ def test_debuginfo_DICompileUnit_language_and_producer():
 
     sycl_queue = dpctl.get_current_queue()
     sig = (
-        npytypes_array_to_dppy_array(types.float32[:]),
-        npytypes_array_to_dppy_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
+        npytypes_array_to_dpex_array(types.float32[:]),
     )
 
     kernel_ir = get_kernel_ir(sycl_queue, func, sig, debug=True)

--- a/numba_dppy/utils/__init__.py
+++ b/numba_dppy/utils/__init__.py
@@ -42,8 +42,8 @@ from numba_dppy.utils.misc import (
     assert_no_return,
 )
 from numba_dppy.utils.type_conversion_fns import (
-    npytypes_array_to_dppy_array,
-    suai_to_dppy_array_type,
+    npytypes_array_to_dpex_array,
+    suai_to_dpex_array,
 )
 
 __all__ = [
@@ -53,9 +53,9 @@ __all__ = [
     "create_null_ptr",
     "get_zero",
     "get_one",
-    "npytypes_array_to_dppy_array",
-    "npytypes_array_to_dppy_array",
-    "suai_to_dppy_array_type",
+    "npytypes_array_to_dpex_array",
+    "npytypes_array_to_dpex_array",
+    "suai_to_dpex_array",
     "address_space",
     "calling_conv",
     "has_usm_memory",

--- a/numba_dppy/utils/array_utils.py
+++ b/numba_dppy/utils/array_utils.py
@@ -66,7 +66,7 @@ def get_info_from_suai(obj):
 
 def has_usm_memory(obj):
     """
-    Determine and return a SYCL device accesible object.
+    Determine and return a SYCL device accessible object.
 
     as_usm_memory() converts Python object with `__sycl_usm_array_interface__`
     property to one of :class:`.MemoryUSMShared`, :class:`.MemoryUSMDevice`, or
@@ -180,7 +180,7 @@ def copy_to_numpy_from_usm_obj(usm_allocated, obj):
 
     if obj.dtype not in [np.dtype(typ) for typ in supported_numpy_dtype]:
         raise ValueError(
-            "dtype is not supprted. Supported dtypes "
+            "dtype is not supported. Supported dtypes "
             "are: %s" % (supported_numpy_dtype)
         )
 

--- a/numba_dppy/utils/type_conversion_fns.py
+++ b/numba_dppy/utils/type_conversion_fns.py
@@ -12,55 +12,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Provides helper functions to convert from numba types to numba_dppy types.
+""" Provides helper functions to convert from numba types to dpex types.
 
 Currently the module supports the following converter functions:
-    - npytypes_array_to_dppy_array: types.npytypes.Array to
-                                    numba_dppy.dppy_array_type.DPPYArray.
+    - types.npytypes.Array to numba_dpex.core.types.Array.
 
 """
 from numba.core import types
 from numba.np import numpy_support
 
-from numba_dppy import dppy_array_type
+from numba_dppy.core.types import Array
 
 from .array_utils import get_info_from_suai
 from .constants import address_space
 
-__all__ = ["npytypes_array_to_dppy_array", "suai_to_dppy_array_type"]
+__all__ = ["npytypes_array_to_dpex_array", "suai_to_dpex_array"]
 
 
-def npytypes_array_to_dppy_array(arrtype, addrspace=address_space.GLOBAL):
-    """Convert   Numba's Array type to numba_dppy's DPPYArray type.
+def npytypes_array_to_dpex_array(arrtype, addrspace=address_space.GLOBAL):
+    """Converts Numba's ``Array`` type to ``numba_dpex.core.types.Array``
+    type.
 
     Numba's ``Array`` type does not have a notion of address space for the data
-    pointer. numba_dppy defines its own array type, DPPYArray, that is similar
-    to Numba's Array, but the data pointer has an associated address space.
-    In addition, the ``meminfo`` and the ``parent`` attributes of ``Array``
-    are stored as ``CPointer`` types instead of ``PyObject``. The converter
-    function converts the Numba ``Array`` type to ``DPPYArray`` type with
-    address space of pointer members typed to the specified address space.
+    pointer. To get around the issues, numba_dpex defines its own array type
+    that is inherits from Numba's Array type. In the
+    ``numba_dpex.core.types.Array`` type the data pointer has an
+    associated address space. In addition, the ``meminfo`` and the ``parent``
+    attributes are stored as ``CPointer`` types instead of ``PyObject``.
+
+    The converter function converts the Numba ``Array`` type to
+    ``numba_dpex.core.types.Array`` type with address space of pointer
+    members typed to the specified address space.
 
     Args:
         arrtype (numba.types): A numba data type that should be
             ``numba.types.Array``.
-        specified: Defaults to ``numba_dppy.utils.address_space.GLOBAL``.
+        specified: Defaults to ``numba_dpex.utils.address_space.GLOBAL``.
             The SPIR-V address space to which the data pointer of the array
             belongs.
 
-    Returns: The numba_dppy data type corresponding to the input numba type.
+    Returns: The dpex data type corresponding to the input numba type.
 
     Raises:
         NotImplementedError: If the input numba type is not
                              ``numba.types.Array``
 
     """
-    # We are not using isinstance() here as we want to
-    # strictly match with types.Array. There are Numba-dppy types
-    # that inherit from types.Array and those type would
-    # also get trapped if isinstance() is used.
+    # We are not using isinstance() here as we want to strictly match with
+    # numba.types.Array and not with a subtype such as
+    # numba_dpex.core.types.Array.
     if type(arrtype) is types.npytypes.Array:
-        return dppy_array_type.DPPYArray(
+        return Array(
             arrtype.dtype,
             arrtype.ndim,
             arrtype.layout,
@@ -73,10 +75,10 @@ def npytypes_array_to_dppy_array(arrtype, addrspace=address_space.GLOBAL):
         raise NotImplementedError
 
 
-def suai_to_dppy_array_type(arr, addrspace=address_space.GLOBAL):
+def suai_to_dpex_array(arr, addrspace=address_space.GLOBAL):
     """Create type for Array with __sycl_usm_array_interface__ (SUAI) attribute.
 
-    This function cretes a Numba type for arrays with SUAI attribute.
+    This function creates a Numba type for arrays with SUAI attribute.
 
     Args:
         arr: Array with SUAI attribute.


### PR DESCRIPTION
Renames `numba_dppy.dppy_array_type` to `numba_dppy.core.types.array_type`. Also renames `DPPYArray` and `DPPYArrayModel` to just `Array` and `ArrayModel`.