### PR TITLE
Rename/dppy to dpex part3

### DIFF
--- a/numba_dppy/examples/atomic_op.py
+++ b/numba_dppy/examples/atomic_op.py
@@ -15,7 +15,7 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
 def main():
@@ -36,9 +36,9 @@ def main():
     implementation for floating point atomics.
     """
 
-    @dppy.kernel
+    @dpex.kernel
     def atomic_add(a):
-        dppy.atomic.add(a, 0, 1)
+        dpex.atomic.add(a, 0, 1)
 
     global_size = 100
     a = np.array([0], dtype=np.float32)
@@ -50,7 +50,7 @@ def main():
     device.print_device_info()
 
     with dpctl.device_context(device):
-        atomic_add[global_size, dppy.DEFAULT_LOCAL_SIZE](a)
+        atomic_add[global_size, dpex.DEFAULT_LOCAL_SIZE](a)
 
     # Expected 100, because global_size = 100
     print(a)

--- a/numba_dppy/examples/auto_offload_examples/sum-1d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-1d.py
@@ -16,8 +16,6 @@ import dpctl
 import numpy as np
 from numba import njit
 
-import numba_dppy as dppy
-
 
 @njit
 def f1(a, b):

--- a/numba_dppy/examples/auto_offload_examples/sum-2d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-2d.py
@@ -16,8 +16,6 @@ import dpctl
 import numpy as np
 from numba import gdb, njit
 
-import numba_dppy as dppy
-
 
 @njit
 def f1(a, b):

--- a/numba_dppy/examples/auto_offload_examples/sum-3d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-3d.py
@@ -16,8 +16,6 @@ import dpctl
 import numpy as np
 from numba import njit
 
-import numba_dppy as dppy
-
 
 @njit
 def f1(a, b):

--- a/numba_dppy/examples/auto_offload_examples/sum-4d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-4d.py
@@ -16,8 +16,6 @@ import dpctl
 import numpy as np
 from numba import njit
 
-import numba_dppy as dppy
-
 
 @njit
 def f1(a, b):

--- a/numba_dppy/examples/auto_offload_examples/sum-5d.py
+++ b/numba_dppy/examples/auto_offload_examples/sum-5d.py
@@ -16,8 +16,6 @@ import dpctl
 import numpy as np
 from numba import gdb, njit
 
-import numba_dppy as dppy
-
 
 @njit
 def f1(a, b):

--- a/numba_dppy/examples/barrier.py
+++ b/numba_dppy/examples/barrier.py
@@ -16,7 +16,7 @@ import dpctl
 import numpy as np
 from numba import float32
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
 def no_arg_barrier_support():
@@ -26,12 +26,12 @@ def no_arg_barrier_support():
     a ``kernel`` and is equivalent to OpenCL's ``barrier`` function.
     """
 
-    @dppy.kernel
+    @dpex.kernel
     def twice(A):
-        i = dppy.get_global_id(0)
+        i = dpex.get_global_id(0)
         d = A[i]
         # no argument defaults to global mem fence
-        dppy.barrier()
+        dpex.barrier()
         A[i] = d * 2
 
     N = 10
@@ -45,7 +45,7 @@ def no_arg_barrier_support():
     device.print_device_info()
 
     with dpctl.device_context(device):
-        twice[N, dppy.DEFAULT_LOCAL_SIZE](arr)
+        twice[N, dpex.DEFAULT_LOCAL_SIZE](arr)
 
     # the output should be `arr * 2, i.e. [0, 2, 4, 6, ...]`
     print(arr)
@@ -59,15 +59,15 @@ def local_memory():
     """
     blocksize = 10
 
-    @dppy.kernel
+    @dpex.kernel
     def reverse_array(A):
-        lm = dppy.local.array(shape=10, dtype=float32)
-        i = dppy.get_global_id(0)
+        lm = dpex.local.array(shape=10, dtype=float32)
+        i = dpex.get_global_id(0)
 
         # preload
         lm[i] = A[i]
         # barrier local or global will both work as we only have one work group
-        dppy.barrier(dppy.CLK_LOCAL_MEM_FENCE)  # local mem fence
+        dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)  # local mem fence
         # write
         A[i] += lm[blocksize - 1 - i]
 
@@ -81,7 +81,7 @@ def local_memory():
     device.print_device_info()
 
     with dpctl.device_context(device):
-        reverse_array[blocksize, dppy.DEFAULT_LOCAL_SIZE](arr)
+        reverse_array[blocksize, dpex.DEFAULT_LOCAL_SIZE](arr)
 
     # the output should be `orig[::-1] + orig, i.e. [9, 9, 9, ...]``
     print(arr)

--- a/numba_dppy/examples/blacksholes_kernel.py
+++ b/numba_dppy/examples/blacksholes_kernel.py
@@ -17,7 +17,7 @@ import math
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 RISKFREE = 0.02
 VOLATILITY = 0.30
@@ -44,13 +44,13 @@ callResult = np.zeros(OPT_N)
 putResult = -np.ones(OPT_N)
 
 
-@dppy.kernel
+@dpex.kernel
 def black_scholes_dppy(callResult, putResult, S, X, T, R, V):
     """
     A simple implementation of the Black-Scholes formula using explicit
     OpenCL-syle kernel programming model.
     """
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     if i >= S.shape[0]:
         return
     sqrtT = math.sqrt(T[i])

--- a/numba_dppy/examples/blacksholes_njit.py
+++ b/numba_dppy/examples/blacksholes_njit.py
@@ -20,8 +20,6 @@ import dpctl
 import numba
 import numpy as np
 
-import numba_dppy as dppy
-
 
 @numba.vectorize(nopython=True)
 def cndf2(inp):

--- a/numba_dppy/examples/debug/dppy_func.py
+++ b/numba_dppy/examples/debug/dppy_func.py
@@ -15,18 +15,18 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.func(debug=True)
+@dpex.func(debug=True)
 def func_sum(a_in_func, b_in_func):
     result = a_in_func + b_in_func
     return result
 
 
-@dppy.kernel(debug=True)
+@dpex.kernel(debug=True)
 def kernel_sum(a_in_kernel, b_in_kernel, c_in_kernel):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     c_in_kernel[i] = func_sum(a_in_kernel[i], b_in_kernel[i])
 
 
@@ -34,7 +34,7 @@ def driver(a, b, c, global_size):
     print("a = ", a)
     print("b = ", b)
     print("c = ", c)
-    kernel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+    kernel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
     print("a + b = ", c)
 
 

--- a/numba_dppy/examples/debug/side-by-side-2.py
+++ b/numba_dppy/examples/debug/side-by-side-2.py
@@ -18,7 +18,7 @@ import dpctl
 import numba
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
 def common_loop_body(i, a, b):
@@ -60,17 +60,17 @@ def numba_func_driver(a, b, c):
 def dppy_func_driver(a, b, c):
     device = dpctl.select_default_device()
     with dpctl.device_context(device):
-        dppy_kernel[len(c), dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+        kernel[len(c), dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 
 
-@dppy.kernel(debug=True)
-def dppy_kernel(a_in_kernel, b_in_kernel, c_in_kernel):
-    i = dppy.get_global_id(0)
+@dpex.kernel(debug=True)
+def kernel(a_in_kernel, b_in_kernel, c_in_kernel):
+    i = dpex.get_global_id(0)
     c_in_kernel[i] = dppy_loop_body(i, a_in_kernel, b_in_kernel)
 
 
 numba_loop_body = numba.njit(debug=True)(common_loop_body)
-dppy_loop_body = dppy.func(debug=True)(common_loop_body)
+dppy_loop_body = dpex.func(debug=True)(common_loop_body)
 
 
 def main():

--- a/numba_dppy/examples/debug/side-by-side.py
+++ b/numba_dppy/examples/debug/side-by-side.py
@@ -18,7 +18,7 @@ import dpctl
 import numba
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
 def common_loop_body(param_a, param_b):
@@ -58,17 +58,17 @@ def numba_func_driver(a, b, c):
 def dppy_func_driver(a, b, c):
     device = dpctl.select_default_device()
     with dpctl.device_context(device):
-        dppy_kernel[len(c), dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+        kernel[len(c), dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 
 
-@dppy.kernel(debug=True)
-def dppy_kernel(a_in_kernel, b_in_kernel, c_in_kernel):
-    i = dppy.get_global_id(0)
+@dpex.kernel(debug=True)
+def kernel(a_in_kernel, b_in_kernel, c_in_kernel):
+    i = dpex.get_global_id(0)
     c_in_kernel[i] = dppy_loop_body(a_in_kernel[i], b_in_kernel[i])
 
 
 numba_loop_body = numba.njit(debug=True)(common_loop_body)
-dppy_loop_body = dppy.func(debug=True)(common_loop_body)
+dppy_loop_body = dpex.func(debug=True)(common_loop_body)
 
 
 def main():

--- a/numba_dppy/examples/debug/simple_dppy_func.py
+++ b/numba_dppy/examples/debug/simple_dppy_func.py
@@ -15,18 +15,18 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.func(debug=True)
+@dpex.func(debug=True)
 def func_sum(a_in_func, b_in_func):
     result = a_in_func + b_in_func
     return result
 
 
-@dppy.kernel(debug=True)
+@dpex.kernel(debug=True)
 def kernel_sum(a_in_kernel, b_in_kernel, c_in_kernel):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     c_in_kernel[i] = func_sum(a_in_kernel[i], b_in_kernel[i])
 
 
@@ -37,6 +37,6 @@ c = np.empty_like(a)
 
 device = dpctl.SyclDevice("opencl:gpu")
 with dpctl.device_context(device):
-    kernel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+    kernel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 
 print("Done...")

--- a/numba_dppy/examples/debug/simple_sum.py
+++ b/numba_dppy/examples/debug/simple_sum.py
@@ -15,12 +15,12 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel(debug=True)
+@dpex.kernel(debug=True)
 def data_parallel_sum(a, b, c):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     c[i] = a[i] + b[i]  # Condition breakpoint location
 
 
@@ -33,6 +33,6 @@ c = np.ones_like(a)
 
 device = dpctl.SyclDevice("opencl:gpu")
 with dpctl.device_context(device):
-    data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+    data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 
 print("Done...")

--- a/numba_dppy/examples/debug/sum.py
+++ b/numba_dppy/examples/debug/sum.py
@@ -15,12 +15,12 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel(debug=True)
+@dpex.kernel(debug=True)
 def data_parallel_sum(a_in_kernel, b_in_kernel, c_in_kernel):
-    i = dppy.get_global_id(0)  # numba-kernel-breakpoint
+    i = dpex.get_global_id(0)  # numba-kernel-breakpoint
     l1 = a_in_kernel[i]  # second-line
     l2 = b_in_kernel[i]  # third-line
     c_in_kernel[i] = l1 + l2  # fourth-line
@@ -30,7 +30,7 @@ def driver(a, b, c, global_size):
     print("before : ", a)
     print("before : ", b)
     print("before : ", c)
-    data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+    data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
     print("after : ", c)
 
 

--- a/numba_dppy/examples/debug/sum_local_vars.py
+++ b/numba_dppy/examples/debug/sum_local_vars.py
@@ -15,12 +15,12 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel(debug=True)
+@dpex.kernel(debug=True)
 def data_parallel_sum(a, b, c):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     l1 = a[i] + 2.5
     l2 = b[i] * 0.3
     c[i] = l1 + l2
@@ -35,6 +35,6 @@ c = np.ones_like(a)
 
 device = dpctl.SyclDevice("opencl:gpu")
 with dpctl.device_context(device):
-    data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+    data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 
 print("Done...")

--- a/numba_dppy/examples/debug/sum_local_vars_revive.py
+++ b/numba_dppy/examples/debug/sum_local_vars_revive.py
@@ -15,17 +15,17 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.func
+@dpex.func
 def revive(x):
     return x
 
 
-@dppy.kernel(debug=True)
+@dpex.kernel(debug=True)
 def data_parallel_sum(a, b, c):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     l1 = a[i] + 2.5
     l2 = b[i] * 0.3
     c[i] = l1 + l2
@@ -41,6 +41,6 @@ c = np.ones_like(a)
 
 device = dpctl.SyclDevice("opencl:gpu")
 with dpctl.device_context(device):
-    data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+    data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 
 print("Done...")

--- a/numba_dppy/examples/dppy_func.py
+++ b/numba_dppy/examples/dppy_func.py
@@ -15,10 +15,10 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.func
+@dpex.func
 def a_device_function(a):
     """
     A ``func`` is a device callable function that can be invoked from
@@ -27,21 +27,21 @@ def a_device_function(a):
     return a + 1
 
 
-@dppy.func
+@dpex.func
 def another_device_function(a):
     return a_device_function(a)
 
 
-@dppy.kernel
+@dpex.kernel
 def a_kernel_function(a, b):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     b[i] = another_device_function(a[i])
 
 
 def driver(a, b, N):
     print(b)
     print("--------")
-    a_kernel_function[N, dppy.DEFAULT_LOCAL_SIZE](a, b)
+    a_kernel_function[N, dpex.DEFAULT_LOCAL_SIZE](a, b)
     print(b)
 
 

--- a/numba_dppy/examples/matmul.py
+++ b/numba_dppy/examples/matmul.py
@@ -16,16 +16,16 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel
+@dpex.kernel
 def dppy_gemm(a, b, c):
     """
     A basic DGEMM implemented as a ``kernel`` function.
     """
-    i = dppy.get_global_id(0)
-    j = dppy.get_global_id(1)
+    i = dpex.get_global_id(0)
+    j = dpex.get_global_id(1)
     if i >= c.shape[0] or j >= c.shape[1]:
         return
     c[i, j] = 0

--- a/numba_dppy/examples/pairwise_distance.py
+++ b/numba_dppy/examples/pairwise_distance.py
@@ -20,7 +20,7 @@ import dpctl
 import dpctl.memory as dpctl_mem
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 parser = argparse.ArgumentParser(
     description="Program to compute pairwise distance"
@@ -42,13 +42,13 @@ X = np.random.random((args.n, args.d))
 D = np.empty((args.n, args.n))
 
 
-@dppy.kernel
+@dpex.kernel
 def pairwise_distance(X, D, xshape0, xshape1):
     """
     An Euclidean pairwise distance computation implemented as
     a ``kernel`` function.
     """
-    idx = dppy.get_global_id(0)
+    idx = dpex.get_global_id(0)
 
     # for i in range(xshape0):
     for j in range(X.shape[0]):

--- a/numba_dppy/examples/sum.py
+++ b/numba_dppy/examples/sum.py
@@ -17,22 +17,22 @@ import dpctl
 import numpy as np
 import numpy.testing as testing
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel
+@dpex.kernel
 def data_parallel_sum(a, b, c):
     """
     Vector addition using the ``kernel`` decorator.
     """
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     c[i] = a[i] + b[i]
 
 
 def driver(a, b, c, global_size):
     print("A : ", a)
     print("B : ", b)
-    data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+    data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
     print("A + B = ")
     print("C ", c)
     testing.assert_equal(c, a + b)

--- a/numba_dppy/examples/sum2D.py
+++ b/numba_dppy/examples/sum2D.py
@@ -16,23 +16,23 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel
+@dpex.kernel
 def data_parallel_sum(a, b, c):
     """
     A two-dimensional vector addition example using the ``kernel`` decorator.
     """
-    i = dppy.get_global_id(0)
-    j = dppy.get_global_id(1)
+    i = dpex.get_global_id(0)
+    j = dpex.get_global_id(1)
     c[i, j] = a[i, j] + b[i, j]
 
 
 def driver(a, b, c, global_size):
     print("before A: ", a)
     print("before B: ", b)
-    data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+    data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
     print("after  C : ", c)
 
 

--- a/numba_dppy/examples/sum_ndarray.py
+++ b/numba_dppy/examples/sum_ndarray.py
@@ -17,10 +17,10 @@ import dpctl
 import numpy as np
 from _helper import has_cpu, has_gpu
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel(
+@dpex.kernel(
     access_types={
         "read_only": ["a", "b"],
         "write_only": ["c"],
@@ -28,7 +28,7 @@ import numba_dppy as dppy
     }
 )
 def data_parallel_sum(a, b, c):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     c[i] = a[i] + b[i]
 
 

--- a/numba_dppy/examples/sum_reduction.py
+++ b/numba_dppy/examples/sum_reduction.py
@@ -17,12 +17,12 @@ import math
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel
+@dpex.kernel
 def sum_reduction_kernel(A, R, stride):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     # sum two element
     R[i] = A[i] + A[i + stride]
     # store the sum to be used in nex iteration
@@ -44,7 +44,7 @@ def sum_reduce(A):
     with dpctl.device_context(device):
         while total > 1:
             global_size = total // 2
-            sum_reduction_kernel[global_size, dppy.DEFAULT_LOCAL_SIZE](
+            sum_reduction_kernel[global_size, dpex.DEFAULT_LOCAL_SIZE](
                 A, R, global_size
             )
             total = total // 2

--- a/numba_dppy/examples/sum_reduction_ocl.py
+++ b/numba_dppy/examples/sum_reduction_ocl.py
@@ -16,21 +16,21 @@ import dpctl
 import numpy as np
 from numba import int32
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel
+@dpex.kernel
 def sum_reduction_kernel(A, partial_sums):
     """
     The example demonstrates a reduction kernel implemented as a ``kernel``
     function.
     """
-    local_id = dppy.get_local_id(0)
-    global_id = dppy.get_global_id(0)
-    group_size = dppy.get_local_size(0)
-    group_id = dppy.get_group_id(0)
+    local_id = dpex.get_local_id(0)
+    global_id = dpex.get_global_id(0)
+    group_size = dpex.get_local_size(0)
+    group_id = dpex.get_group_id(0)
 
-    local_sums = dppy.local.array(64, int32)
+    local_sums = dpex.local.array(64, int32)
 
     # Copy from global to local memory
     local_sums[local_id] = A[global_id]
@@ -39,7 +39,7 @@ def sum_reduction_kernel(A, partial_sums):
     stride = group_size // 2
     while stride > 0:
         # Waiting for each 2x2 addition into given workgroup
-        dppy.barrier(dppy.CLK_LOCAL_MEM_FENCE)
+        dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 
         # Add elements 2 by 2 between local_id and local_id + stride
         if local_id < stride:

--- a/numba_dppy/examples/sum_reduction_recursive_ocl.py
+++ b/numba_dppy/examples/sum_reduction_recursive_ocl.py
@@ -23,17 +23,17 @@ import dpctl.memory as dpctl_mem
 import numpy as np
 from numba import int32
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel
+@dpex.kernel
 def sum_reduction_kernel(A, input_size, partial_sums):
-    local_id = dppy.get_local_id(0)
-    global_id = dppy.get_global_id(0)
-    group_size = dppy.get_local_size(0)
-    group_id = dppy.get_group_id(0)
+    local_id = dpex.get_local_id(0)
+    global_id = dpex.get_global_id(0)
+    group_size = dpex.get_local_size(0)
+    group_id = dpex.get_group_id(0)
 
-    local_sums = dppy.local.array(64, int32)
+    local_sums = dpex.local.array(64, int32)
 
     local_sums[local_id] = 0
 
@@ -44,7 +44,7 @@ def sum_reduction_kernel(A, input_size, partial_sums):
     stride = group_size // 2
     while stride > 0:
         # Waiting for each 2x2 addition into given workgroup
-        dppy.barrier(dppy.CLK_LOCAL_MEM_FENCE)
+        dpex.barrier(dpex.CLK_LOCAL_MEM_FENCE)
 
         # Add elements 2 by 2 between local_id and local_id + stride
         if local_id < stride:

--- a/numba_dppy/examples/usm_ndarray.py
+++ b/numba_dppy/examples/usm_ndarray.py
@@ -18,22 +18,22 @@ import dpctl.tensor as dpt
 import numpy as np
 import numpy.testing as testing
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 
-@dppy.kernel
+@dpex.kernel
 def data_parallel_sum(a, b, c):
     """
     Vector addition using the ``kernel`` decorator.
     """
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     c[i] = a[i] + b[i]
 
 
 def driver(a, b, c, global_size):
     print("A : ", a)
     print("B : ", b)
-    data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+    data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
     print("A + B = ")
     print("C ", c)
     testing.assert_equal(c, a + b)

--- a/numba_dppy/examples/vectorize.py
+++ b/numba_dppy/examples/vectorize.py
@@ -16,8 +16,6 @@ import dpctl
 import numpy as np
 from numba import float64, vectorize
 
-import numba_dppy as dppy
-
 
 @vectorize(nopython=True)
 def ufunc_kernel(x, y):
@@ -57,7 +55,7 @@ def test_njit():
     print("Done...")
 
 
-@vectorize([float64(float64, float64)], target="dppy")
+@vectorize([float64(float64, float64)], target="dpex")
 def vector_add(a, b):
     return a + b
 

--- a/numba_dppy/tests/integration/test_dpnp_interop.py
+++ b/numba_dppy/tests/integration/test_dpnp_interop.py
@@ -16,7 +16,7 @@ import dpctl
 import numpy as np
 import pytest
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import filter_strings
 
 dpnp = pytest.importorskip("dpnp", reason="DPNP is not installed")
@@ -67,19 +67,19 @@ def test_consuming_array_from_dpnp(filter_str, dtype):
     ):
         pytest.skip("Bug in DPNP. See: IntelPython/dpnp#723")
 
-    @dppy.kernel
+    @dpex.kernel
     def data_parallel_sum(a, b, c):
         """
         Vector addition using the ``kernel`` decorator.
         """
-        i = dppy.get_global_id(0)
+        i = dpex.get_global_id(0)
         c[i] = a[i] + b[i]
 
     global_size = 1021
 
     with dpctl.device_context(filter_str):
-        a = dppy.asarray(dpnp.arange(global_size, dtype=dtype))
-        b = dppy.asarray(dpnp.arange(global_size, dtype=dtype))
-        c = dppy.asarray(dpnp.ones_like(a))
+        a = dpex.asarray(dpnp.arange(global_size, dtype=dtype))
+        b = dpex.asarray(dpnp.arange(global_size, dtype=dtype))
+        c = dpex.asarray(dpnp.ones_like(a))
 
-        data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+        data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)

--- a/numba_dppy/tests/integration/test_sycl_usm_array_iface_interop.py
+++ b/numba_dppy/tests/integration/test_sycl_usm_array_iface_interop.py
@@ -2,14 +2,14 @@ import dpctl
 import numpy as np
 import pytest
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 
 from .DuckUSMArray import DuckUSMArray, PseudoDuckUSMArray
 
 
-@dppy.kernel
+@dpex.kernel
 def vecadd(a, b, c):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     c[i] = a[i] + b[i]
 
 
@@ -48,7 +48,7 @@ def test_dppy_kernel_valid_usm_obj(dtype):
 
     try:
         with dpctl.device_context(dpctl.select_default_device()):
-            vecadd[N, dppy.DEFAULT_LOCAL_SIZE](A, B, C)
+            vecadd[N, dpex.DEFAULT_LOCAL_SIZE](A, B, C)
     except Exception:
         pytest.fail(
             "Could not pass Python object with sycl_usm_array_interface"
@@ -75,4 +75,4 @@ def test_dppy_kernel_invalid_usm_obj(dtype):
 
     with pytest.raises(Exception):
         with dpctl.device_context(dpctl.select_default_device()):
-            vecadd[N, dppy.DEFAULT_LOCAL_SIZE](A, B, C)
+            vecadd[N, dpex.DEFAULT_LOCAL_SIZE](A, B, C)

--- a/numba_dppy/tests/integration/test_usm_ndarray_interop.py
+++ b/numba_dppy/tests/integration/test_usm_ndarray_interop.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import filter_strings
 
 list_of_dtype = [
@@ -48,13 +48,13 @@ def usm_type(request):
 
 @pytest.mark.parametrize("filter_str", filter_strings)
 def test_consuming_usm_ndarray(filter_str, dtype, usm_type):
-    @dppy.kernel
+    @dpex.kernel
     def data_parallel_sum(a, b, c):
         """
         Vector addition using the ``kernel`` decorator.
         """
-        i = dppy.get_global_id(0)
-        j = dppy.get_global_id(1)
+        i = dpex.get_global_id(0)
+        j = dpex.get_global_id(1)
         c[i, j] = a[i, j] + b[i, j]
 
     N = 1021
@@ -89,7 +89,7 @@ def test_consuming_usm_ndarray(filter_str, dtype, usm_type):
             buffer_ctor_kwargs={"queue": gpu_queue},
         )
 
-        data_parallel_sum[(N, N), dppy.DEFAULT_LOCAL_SIZE](da, db, dc)
+        data_parallel_sum[(N, N), dpex.DEFAULT_LOCAL_SIZE](da, db, dc)
 
         dc.usm_data.copy_to_host(got.reshape((-1)).view("|u1"))
 

--- a/numba_dppy/tests/kernel_tests/test_arg_accessor.py
+++ b/numba_dppy/tests/kernel_tests/test_arg_accessor.py
@@ -16,7 +16,7 @@ import dpctl
 import numpy as np
 import pytest
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import filter_strings
 
 
@@ -30,7 +30,7 @@ N = global_size * local_size
 
 
 def sum_kernel(a, b, c):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     c[i] = a[i] + b[i]
 
 
@@ -57,7 +57,7 @@ list_of_kernel_opt = [
 
 @pytest.fixture(params=list_of_kernel_opt)
 def kernel(request):
-    return dppy.kernel(access_types=request.param)(sum_kernel)
+    return dpex.kernel(access_types=request.param)(sum_kernel)
 
 
 @pytest.mark.parametrize("filter_str", filter_strings)

--- a/numba_dppy/tests/kernel_tests/test_arg_types.py
+++ b/numba_dppy/tests/kernel_tests/test_arg_types.py
@@ -16,7 +16,7 @@ import dpctl
 import numpy as np
 import pytest
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import filter_strings
 
 global_size = 1054
@@ -25,7 +25,7 @@ N = global_size * local_size
 
 
 def mul_kernel(a, b, c):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     b[i] = a[i] * c
 
 
@@ -47,7 +47,7 @@ def input_arrays(request):
 
 @pytest.mark.parametrize("filter_str", filter_strings)
 def test_kernel_arg_types(filter_str, input_arrays):
-    kernel = dppy.kernel(mul_kernel)
+    kernel = dpex.kernel(mul_kernel)
     a, actual, c = input_arrays
     expected = a * c
     device = dpctl.SyclDevice(filter_str)
@@ -65,12 +65,12 @@ def check_bool_kernel(A, test):
 
 @pytest.mark.parametrize("filter_str", filter_strings)
 def test_bool_type(filter_str):
-    kernel = dppy.kernel(check_bool_kernel)
+    kernel = dpex.kernel(check_bool_kernel)
     a = np.array([2], np.int64)
 
     device = dpctl.SyclDevice(filter_str)
     with dpctl.device_context(device):
-        kernel[a.size, dppy.DEFAULT_LOCAL_SIZE](a, True)
+        kernel[a.size, dpex.DEFAULT_LOCAL_SIZE](a, True)
         assert a[0] == 111
-        kernel[a.size, dppy.DEFAULT_LOCAL_SIZE](a, False)
+        kernel[a.size, dpex.DEFAULT_LOCAL_SIZE](a, False)
         assert a[0] == 222

--- a/numba_dppy/tests/kernel_tests/test_math_functions.py
+++ b/numba_dppy/tests/kernel_tests/test_math_functions.py
@@ -18,7 +18,7 @@ import dpctl
 import numpy as np
 import pytest
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import filter_strings
 
 list_of_unary_ops = ["fabs", "exp", "log", "sqrt", "sin", "cos", "tan"]
@@ -50,14 +50,14 @@ def test_binary_ops(filter_str, unary_op, input_arrays):
     uop = getattr(math, unary_op)
     np_uop = getattr(np, unary_op)
 
-    @dppy.kernel
+    @dpex.kernel
     def f(a, b):
-        i = dppy.get_global_id(0)
+        i = dpex.get_global_id(0)
         b[i] = uop(a[i])
 
     device = dpctl.SyclDevice(filter_str)
     with dpctl.device_context(device):
-        f[a.size, dppy.DEFAULT_LOCAL_SIZE](a, actual)
+        f[a.size, dpex.DEFAULT_LOCAL_SIZE](a, actual)
 
     expected = np_uop(a)
 

--- a/numba_dppy/tests/kernel_tests/test_print.py
+++ b/numba_dppy/tests/kernel_tests/test_print.py
@@ -16,7 +16,7 @@ import dpctl
 import numpy as np
 import pytest
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import filter_strings_opencl_gpu
 
 
@@ -30,7 +30,7 @@ def test_print_only_str(filter_str):
     except Exception:
         pytest.skip()
 
-    @dppy.kernel
+    @dpex.kernel
     def f():
         print("test", "test2")
 
@@ -41,7 +41,7 @@ def test_print_only_str(filter_str):
     # to lack of support for puts() in OpenCL.
 
     with dpctl.device_context(filter_str):
-        f[3, dppy.DEFAULT_LOCAL_SIZE]()
+        f[3, dpex.DEFAULT_LOCAL_SIZE]()
 
 
 list_of_dtypes = [
@@ -61,7 +61,7 @@ def input_arrays(request):
 
 @pytest.mark.parametrize("filter_str", filter_strings_opencl_gpu)
 def test_print(filter_str, input_arrays, capfd):
-    @dppy.kernel
+    @dpex.kernel
     def f(a):
         print("test", a[0])
 
@@ -70,6 +70,6 @@ def test_print(filter_str, input_arrays, capfd):
 
     device = dpctl.SyclDevice(filter_str)
     with dpctl.device_context(device):
-        f[global_size, dppy.DEFAULT_LOCAL_SIZE](a)
+        f[global_size, dpex.DEFAULT_LOCAL_SIZE](a)
         captured = capfd.readouterr()
         assert "test" in captured.out

--- a/numba_dppy/tests/kernel_tests/test_return_type.py
+++ b/numba_dppy/tests/kernel_tests/test_return_type.py
@@ -16,7 +16,7 @@ import dpctl
 import numpy as np
 import pytest
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import filter_strings
 
 
@@ -40,8 +40,8 @@ def test_return(filter_str, sig):
     a = np.array(np.random.random(122), np.int32)
 
     with pytest.raises(TypeError):
-        kernel = dppy.kernel(sig)(f)
+        kernel = dpex.kernel(sig)(f)
 
         device = dpctl.SyclDevice(filter_str)
         with dpctl.device_context(device):
-            kernel[a.size, dppy.DEFAULT_LOCAL_SIZE](a)
+            kernel[a.size, dpex.DEFAULT_LOCAL_SIZE](a)

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_creation.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_creation.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import dpnp_debug, filter_strings, skip_no_dpnp
 
 from ._helper import args_string, wrapper_function

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_ops.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_array_ops.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import (
     dpnp_debug,
     filter_strings,

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_indexing.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_indexing.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import dpnp_debug, filter_strings, skip_no_dpnp
 
 pytestmark = skip_no_dpnp

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_linalg.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_linalg.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import (
     dpnp_debug,
     filter_strings,

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_manipulation.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_manipulation.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import dpnp_debug, filter_strings, skip_no_dpnp
 
 pytestmark = skip_no_dpnp

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_rng.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_rng.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import (
     dpnp_debug,
     filter_strings_level_zero_gpu,
@@ -172,7 +171,7 @@ def test_three_arg_fn(filter_str, three_arg_fn, three_arg_size, capfd):
     elif op_name == "multivariate_normal":
         pytest.skip(
             "No implementation of function Function(<class "
-            "'numba_dppy.dpnp_iface.stubs.dpnp.multivariate_normal'>) found for signature"
+            "'numba_dpex.dpnp_iface.stubs.dpnp.multivariate_normal'>) found for signature"
         )
     elif op_name == "negative_binomial":
         pytest.skip("DPNP RNG Error: dpnp_rng_negative_binomial_c() failed.")

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_sort_search_count.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_sort_search_count.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import dpnp_debug, filter_strings, skip_no_dpnp
 
 from ._helper import wrapper_function

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_statistics.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_statistics.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import (
     dpnp_debug,
     filter_strings_with_skips_for_opencl,

--- a/numba_dppy/tests/njit_tests/dpnp/test_numpy_transcendentals.py
+++ b/numba_dppy/tests/njit_tests/dpnp/test_numpy_transcendentals.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import (
     dpnp_debug,
     filter_strings,

--- a/numba_dppy/tests/njit_tests/test_numpy_bitwise_ops.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_bitwise_ops.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import assert_auto_offloading, filter_strings
 
 list_of_binary_ops = [

--- a/numba_dppy/tests/njit_tests/test_numpy_logic_ops.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_logic_ops.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import assert_auto_offloading, filter_strings
 
 list_of_binary_ops = [

--- a/numba_dppy/tests/njit_tests/test_numpy_transcedental_functions.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_transcedental_functions.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import (
     assert_auto_offloading,
     filter_strings,

--- a/numba_dppy/tests/njit_tests/test_numpy_trigonometric_functions.py
+++ b/numba_dppy/tests/njit_tests/test_numpy_trigonometric_functions.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 from numba import njit
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import (
     assert_auto_offloading,
     filter_strings,

--- a/numba_dppy/tests/test_black_scholes.py
+++ b/numba_dppy/tests/test_black_scholes.py
@@ -18,7 +18,7 @@ import time
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import skip_no_opencl_gpu
 
 RISKFREE = 0.02
@@ -99,10 +99,10 @@ class TestDPPYBlackScholes:
                 VOLATILITY,
             )
 
-        # numba-dppy
-        @dppy.kernel
-        def black_scholes_dppy(callResult, putResult, S, X, T, R, V):
-            i = dppy.get_global_id(0)
+        # numba_dpex
+        @dpex.kernel
+        def black_scholes_dpex(callResult, putResult, S, X, T, R, V):
+            i = dpex.get_global_id(0)
             if i >= S.shape[0]:
                 return
             sqrtT = math.sqrt(T[i])
@@ -141,7 +141,7 @@ class TestDPPYBlackScholes:
         with dpctl.device_context("opencl:gpu"):
             time1 = time.time()
             for i in range(iterations):
-                black_scholes_dppy[blockdim, griddim](
+                black_scholes_dpex[blockdim, griddim](
                     callResultNumbapro,
                     putResultNumbapro,
                     stockPrice,

--- a/numba_dppy/tests/test_debuginfo.py
+++ b/numba_dppy/tests/test_debuginfo.py
@@ -19,7 +19,7 @@ import dpctl
 import pytest
 from numba.core import types
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy import compiler
 from numba_dppy.tests._helper import override_config
 from numba_dppy.utils import npytypes_array_to_dpex_array
@@ -54,7 +54,7 @@ def test_debug_flag_generates_ir_with_debuginfo(debug_option):
     Check debug info is emitting to IR if debug parameter is set to True
     """
 
-    @dppy.kernel
+    @dpex.kernel
     def foo(x):
         x = 1  # noqa
 
@@ -77,9 +77,9 @@ def test_debug_info_locals_vars_on_no_opt():
     if debug parameter is set to True and optimization is O0
     """
 
-    @dppy.kernel
+    @dpex.kernel
     def foo(var_a, var_b, var_c):
-        i = dppy.get_global_id(0)
+        i = dpex.get_global_id(0)
         var_c[i] = var_a[i] + var_b[i]
 
     ir_tags = [
@@ -109,9 +109,9 @@ def test_debug_kernel_local_vars_in_ir():
     created in kernel
     """
 
-    @dppy.kernel
+    @dpex.kernel
     def foo(arr):
-        index = dppy.get_global_id(0)
+        index = dpex.get_global_id(0)
         local_d = 9 * 99 + 5
         arr[index] = local_d + 100
 
@@ -134,14 +134,14 @@ def test_debug_flag_generates_ir_with_debuginfo_for_func(debug_option):
     Check debug info is emitting to IR if debug parameter is set to True
     """
 
-    @dppy.func(debug=debug_option)
+    @dpex.func(debug=debug_option)
     def func_sum(a, b):
         result = a + b
         return result
 
-    @dppy.kernel(debug=debug_option)
+    @dpex.kernel(debug=debug_option)
     def data_parallel_sum(a, b, c):
-        i = dppy.get_global_id(0)
+        i = dpex.get_global_id(0)
         c[i] = func_sum(a[i], b[i])
 
     ir_tags = [
@@ -169,14 +169,14 @@ def test_env_var_generates_ir_with_debuginfo_for_func(debug_option):
     Check debug info is emitting to IR if NUMBA_DPPY_DEBUGINFO is set to 1
     """
 
-    @dppy.func
+    @dpex.func
     def func_sum(a, b):
         result = a + b
         return result
 
-    @dppy.kernel
+    @dpex.kernel
     def data_parallel_sum(a, b, c):
-        i = dppy.get_global_id(0)
+        i = dpex.get_global_id(0)
         c[i] = func_sum(a[i], b[i])
 
     ir_tags = [
@@ -199,9 +199,9 @@ def test_env_var_generates_ir_with_debuginfo_for_func(debug_option):
 
 
 def test_debuginfo_DISubprogram_linkageName():
-    @dppy.kernel
+    @dpex.kernel
     def func(a, b):
-        i = dppy.get_global_id(0)
+        i = dpex.get_global_id(0)
         b[i] = a[i]
 
     ir_tags = [
@@ -221,9 +221,9 @@ def test_debuginfo_DISubprogram_linkageName():
 
 
 def test_debuginfo_DICompileUnit_language_and_producer():
-    @dppy.kernel
+    @dpex.kernel
     def func(a, b):
-        i = dppy.get_global_id(0)
+        i = dpex.get_global_id(0)
         b[i] = a[i]
 
     ir_tags = [

--- a/numba_dppy/tests/test_device_array_args.py
+++ b/numba_dppy/tests/test_device_array_args.py
@@ -16,13 +16,13 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import skip_no_opencl_cpu, skip_no_opencl_gpu
 
 
-@dppy.kernel
+@dpex.kernel
 def data_parallel_sum(a, b, c):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     c[i] = a[i] + b[i]
 
 
@@ -40,7 +40,7 @@ class TestDPPYDeviceArrayArgsGPU:
         c = np.ones_like(a)
 
         with dpctl.device_context("opencl:cpu"):
-            data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+            data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 
             assert np.all(c == d)
 
@@ -51,6 +51,6 @@ class TestDPPYDeviceArrayArgsCPU:
         c = np.ones_like(a)
 
         with dpctl.device_context("opencl:gpu"):
-            data_parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+            data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 
         assert np.all(c == d)

--- a/numba_dppy/tests/test_dpctl_api.py
+++ b/numba_dppy/tests/test_dpctl_api.py
@@ -15,7 +15,6 @@
 import dpctl
 import pytest
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import filter_strings
 
 

--- a/numba_dppy/tests/test_dppy_func.py
+++ b/numba_dppy/tests/test_dppy_func.py
@@ -15,7 +15,7 @@
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import skip_no_opencl_gpu
 
 
@@ -24,13 +24,13 @@ class TestDPPYFunc:
     N = 257
 
     def test_dppy_func_device_array(self):
-        @dppy.func
+        @dpex.func
         def g(a):
             return a + 1
 
-        @dppy.kernel
+        @dpex.kernel
         def f(a, b):
-            i = dppy.get_global_id(0)
+            i = dpex.get_global_id(0)
             b[i] = g(a[i])
 
         a = np.ones(self.N)
@@ -38,23 +38,23 @@ class TestDPPYFunc:
 
         device = dpctl.SyclDevice("opencl:gpu")
         with dpctl.device_context(device):
-            f[self.N, dppy.DEFAULT_LOCAL_SIZE](a, b)
+            f[self.N, dpex.DEFAULT_LOCAL_SIZE](a, b)
 
         assert np.all(b == 2)
 
     def test_dppy_func_ndarray(self):
-        @dppy.func
+        @dpex.func
         def g(a):
             return a + 1
 
-        @dppy.kernel
+        @dpex.kernel
         def f(a, b):
-            i = dppy.get_global_id(0)
+            i = dpex.get_global_id(0)
             b[i] = g(a[i])
 
-        @dppy.kernel
+        @dpex.kernel
         def h(a, b):
-            i = dppy.get_global_id(0)
+            i = dpex.get_global_id(0)
             b[i] = g(a[i]) + 1
 
         a = np.ones(self.N)
@@ -62,10 +62,10 @@ class TestDPPYFunc:
 
         device = dpctl.SyclDevice("opencl:gpu")
         with dpctl.device_context(device):
-            f[self.N, dppy.DEFAULT_LOCAL_SIZE](a, b)
+            f[self.N, dpex.DEFAULT_LOCAL_SIZE](a, b)
 
             assert np.all(b == 2)
 
-            h[self.N, dppy.DEFAULT_LOCAL_SIZE](a, b)
+            h[self.N, dpex.DEFAULT_LOCAL_SIZE](a, b)
 
             assert np.all(b == 3)

--- a/numba_dppy/tests/test_itanium_mangler_extension.py
+++ b/numba_dppy/tests/test_itanium_mangler_extension.py
@@ -16,7 +16,6 @@ import pytest
 from numba import float32, float64, int32, int64, uint32, uint64
 from numba.core import types
 
-import numba_dppy as dppy
 import numba_dppy.extended_numba_itanium_mangler as itanium_mangler
 from numba_dppy.utils import address_space
 

--- a/numba_dppy/tests/test_no_copy_usm_shared.py
+++ b/numba_dppy/tests/test_no_copy_usm_shared.py
@@ -20,7 +20,6 @@ from numba import prange
 from numba.core import compiler, cpu
 from numba.core.registry import cpu_target
 
-import numba_dppy as dppy
 from numba_dppy.compiler import Compiler
 from numba_dppy.tests._helper import skip_no_opencl_gpu
 

--- a/numba_dppy/tests/test_offload_diagnostics.py
+++ b/numba_dppy/tests/test_offload_diagnostics.py
@@ -17,7 +17,7 @@ import numpy as np
 from numba import njit, prange
 from numba.tests.support import captured_stdout
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy import config as dppy_config
 from numba_dppy.tests._helper import skip_no_opencl_gpu
 
@@ -48,9 +48,9 @@ class TestOffloadDiagnostics:
             assert "Device -" in got.getvalue()
 
     def test_kernel(self):
-        @dppy.kernel
+        @dpex.kernel
         def parallel_sum(a, b, c):
-            i = dppy.get_global_id(0)
+            i = dpex.get_global_id(0)
             c[i] = a[i] + b[i]
 
         global_size = 10
@@ -65,7 +65,7 @@ class TestOffloadDiagnostics:
             dppy_config.OFFLOAD_DIAGNOSTICS = 1
 
             with captured_stdout() as got:
-                parallel_sum[global_size, dppy.DEFAULT_LOCAL_SIZE](a, b, c)
+                parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 
             dppy_config.OFFLOAD_DIAGNOSTICS = 0
             assert "Auto-offloading" in got.getvalue()

--- a/numba_dppy/tests/test_prange.py
+++ b/numba_dppy/tests/test_prange.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 from numba import njit, prange
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import assert_auto_offloading, skip_no_opencl_gpu
 
 

--- a/numba_dppy/tests/test_sum_reduction.py
+++ b/numba_dppy/tests/test_sum_reduction.py
@@ -17,13 +17,13 @@ import math
 import dpctl
 import numpy as np
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy.tests._helper import skip_no_opencl_gpu
 
 
-@dppy.kernel
+@dpex.kernel
 def reduction_kernel(A, R, stride):
-    i = dppy.get_global_id(0)
+    i = dpex.get_global_id(0)
     # sum two element
     R[i] = A[i] + A[i + stride]
     # store the sum to be used in nex iteration
@@ -49,7 +49,7 @@ class TestDPPYSumReduction:
             while total > 1:
                 # call kernel
                 global_size = total // 2
-                reduction_kernel[global_size, dppy.DEFAULT_LOCAL_SIZE](
+                reduction_kernel[global_size, dpex.DEFAULT_LOCAL_SIZE](
                     A, R, global_size
                 )
                 total = total // 2

--- a/numba_dppy/tests/test_vectorize.py
+++ b/numba_dppy/tests/test_vectorize.py
@@ -18,10 +18,7 @@ import numpy as np
 import pytest
 from numba import float32, float64, int32, int64, njit, vectorize
 
-import numba_dppy as dppy
 from numba_dppy.tests._helper import assert_auto_offloading, filter_strings
-
-from . import _helper
 
 list_of_shape = [
     (100, 100),

--- a/numba_dppy/tests/test_with_context.py
+++ b/numba_dppy/tests/test_with_context.py
@@ -18,7 +18,7 @@ import pytest
 from numba import njit
 from numba.tests.support import captured_stdout
 
-import numba_dppy as dppy
+import numba_dppy as dpex
 from numba_dppy import config
 
 from ._helper import (
@@ -46,7 +46,7 @@ def scenario(filter_str, context):
 @pytest.mark.parametrize(
     "context",
     [
-        dppy.offload_to_sycl_device,
+        dpex.offload_to_sycl_device,
         dpctl.device_context,
     ],
 )


### PR DESCRIPTION
Update all tests and examples to use `dpex` as the alias for `numba_dppy`. Once this PR is merged we will be in a position to rename the module.