### PR TITLE
Fix remarks for `dpnp.empty()` #728

### DIFF
--- a/numba_dppy/dpctl_iface/usm_allocators_ext.c
+++ b/numba_dppy/dpctl_iface/usm_allocators_ext.c
@@ -279,10 +279,10 @@ error:
     return NULL;
 }
 
-MOD_INIT(_usm_shared_allocator_ext)
+MOD_INIT(_usm_allocators_ext)
 {
     PyObject *m;
-    MOD_DEF(m, "numba_dppy._usm_shared_allocator_ext", "No docs", ext_methods)
+    MOD_DEF(m, "numba_dppy._usm_allocators_ext", "No docs", ext_methods)
     if (m == NULL)
         return MOD_ERROR_VAL;
     usmarray_memsys_init();

--- a/numba_dppy/dpnp_ndarray/models.py
+++ b/numba_dppy/dpnp_ndarray/models.py
@@ -12,49 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numba import types
-from numba.core.datamodel import StructModel
-from numba.core.datamodel.models import ArrayModel
+from numba.core.datamodel.models import ArrayModel as dpnp_ndarray_Model
 from numba.extending import register_model
 
 from numba_dppy.target import spirv_data_model_manager
 
 from .types import dpnp_ndarray_Type
 
-# we reuse models.ArrayModel
-# it should contain all properties from __sycl_usm_array_interface__
-# __sycl_usm_array_interface__ and __array_interface__ are different
-# _Memory.__sycl_usm_array_interface__ has data, shape, strides, typestr, version, syclobj
-
-
-class dpnp_ndarray_Model(StructModel):
-    """Model for DPNP array.
-
-    It contains all items from models.ArrayModel and adding properties from
-    __sycl_usm_array_interface__: syclobj
-    """
-
-    def __init__(self, dmm, fe_type):
-        ndim = fe_type.ndim
-        members = [
-            # from models.ArrayModel
-            ("meminfo", types.MemInfoPointer(fe_type.dtype)),
-            ("parent", types.pyobject),
-            ("nitems", types.intp),
-            ("itemsize", types.intp),
-            ("data", types.CPointer(fe_type.dtype)),
-            # from __sycl_usm_array_interface__
-            # ("syclobj", types.pyobject),
-            # from models.ArrayModel
-            ("shape", types.UniTuple(types.intp, ndim)),
-            ("strides", types.UniTuple(types.intp, ndim)),
-        ]
-        super().__init__(dmm, fe_type, members)
-
-
 # This tells Numba to use the default Numpy ndarray data layout for
 # object of type dpnp.ndarray.
-# register_model(dpnp_ndarray_Type)(ArrayModel)
-
 register_model(dpnp_ndarray_Type)(dpnp_ndarray_Model)
-spirv_data_model_manager.register(dpnp_ndarray_Type, ArrayModel)
+spirv_data_model_manager.register(dpnp_ndarray_Type, dpnp_ndarray_Model)

--- a/numba_dppy/numpy_usm_shared.py
+++ b/numba_dppy/numpy_usm_shared.py
@@ -74,13 +74,13 @@ def dprint(*args):
 import dpctl
 from dpctl.memory import MemoryUSMShared
 
-import numba_dppy._usm_shared_allocator_ext
+import numba_dppy._usm_allocators_ext
 
 # Register the helper function in dppl_rt so that we can insert calls to them via llvmlite.
 for (
     py_name,
     c_address,
-) in numba_dppy._usm_shared_allocator_ext.c_helpers.items():
+) in numba_dppy._usm_allocators_ext.c_helpers.items():
     llb.add_symbol(py_name, c_address)
 
 
@@ -239,7 +239,7 @@ def is_usm_callback(obj):
         while isinstance(mobj, numba.core.runtime._nrt_python._MemInfo):
             ea = mobj.external_allocator
             dppl_rt_allocator = (
-                numba_dppy._usm_shared_allocator_ext.get_external_allocator()
+                numba_dppy._usm_allocators_ext.get_external_allocator()
             )
             dprint("Checking MemInfo:", ea)
             if ea == dppl_rt_allocator:

--- a/numba_dppy/tests/njit_tests/dpnp_ndarray/runtime/test_usm_allocators_ext.py
+++ b/numba_dppy/tests/njit_tests/dpnp_ndarray/runtime/test_usm_allocators_ext.py
@@ -1,18 +1,18 @@
-"""Tests for numba_dppy._usm_shared_allocator_ext
+"""Tests for numba_dppy._usm_allocators_ext
 """
 
 
 def test_members():
-    from numba_dppy import _usm_shared_allocator_ext
+    from numba_dppy import _usm_allocators_ext
 
     members = ["c_helpers", "get_external_allocator"]
 
     for member in members:
-        assert hasattr(_usm_shared_allocator_ext, member)
+        assert hasattr(_usm_allocators_ext, member)
 
 
 def test_c_helpers():
-    from numba_dppy._usm_shared_allocator_ext import c_helpers
+    from numba_dppy._usm_allocators_ext import c_helpers
 
     functions = [
         "usmarray_get_ext_allocator",
@@ -32,7 +32,7 @@ def test_c_helpers():
 def test_allocator():
     from ctypes import POINTER, PYFUNCTYPE, Structure, c_int, c_size_t, c_void_p
 
-    from numba_dppy._usm_shared_allocator_ext import c_helpers
+    from numba_dppy._usm_allocators_ext import c_helpers
 
     class NRT_ExternalAllocator(Structure):
         _fields_ = [
@@ -68,7 +68,7 @@ def test_meminfo():
 
     from numba.core.runtime import _nrt_python
 
-    from numba_dppy._usm_shared_allocator_ext import c_helpers
+    from numba_dppy._usm_allocators_ext import c_helpers
 
     class MemInfo(Structure):
         _fields_ = [

--- a/numba_dppy/tests/njit_tests/dpnp_ndarray/test_boxing.py
+++ b/numba_dppy/tests/njit_tests/dpnp_ndarray/test_boxing.py
@@ -12,40 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for dpnp.ndarray interoperability with Numba
-
-See numba/tests/test_ndarray_subclasses.py
 """
-
+Tests for boxing for dpnp.ndarray
+"""
 
 import pytest
 from dpctl.tensor.numpy_usm_shared import ndarray as dpctl_ndarray
 from dpnp import ndarray as dpnp_ndarray
-from numba import njit, typeof, types
-
-from numba_dppy.dpnp_ndarray import dpnp_ndarray_Type
-from numba_dppy.numpy_usm_shared import UsmSharedArrayType
-
-
-@pytest.mark.parametrize(
-    "array_type, expected_numba_type",
-    [
-        (dpctl_ndarray, UsmSharedArrayType),
-        (dpnp_ndarray, dpnp_ndarray_Type),
-    ],
-)
-@pytest.mark.parametrize(
-    "shape, expected_ndim",
-    [
-        ([1], 1),
-        ([1, 1], 2),
-    ],
-)
-def test_typeof(array_type, shape, expected_numba_type, expected_ndim):
-    array = array_type(shape)
-    expected_type = expected_numba_type(types.float64, expected_ndim, "C")
-    assert typeof(array) == expected_type
-
+from numba import njit
 
 dpnp_mark = pytest.mark.xfail(raises=TypeError, reason="No unboxing")
 

--- a/numba_dppy/tests/njit_tests/dpnp_ndarray/test_models.py
+++ b/numba_dppy/tests/njit_tests/dpnp_ndarray/test_models.py
@@ -23,21 +23,17 @@ def test_model_for_dpnp_ndarray_Type():
     """Test that model is registered for dpnp_ndarray_Type instances.
 
     The model for dpnp_ndarray_Type is dpnp_ndarray_Model.
-    It contains property "syclobj".
-    This property is PyObject.
+
     """
 
     model = default_manager.lookup(dpnp_ndarray_Type(types.float64, 1, "C"))
     assert isinstance(model, dpnp_ndarray_Model)
 
-    assert "syclobj" not in model._fields
-    # assert model.get_member_fe_type("syclobj") == types.pyobject
-
 
 def test_dpnp_ndarray_Model():
     """Test for dpnp_ndarray_Model.
 
-    It is sumclass of models.StructModel and not a subclass of models.ArrayModel.
+    It is a subclass of models.StructModel and models.ArrayModel.
     """
 
     assert issubclass(dpnp_ndarray_Model, models.StructModel)

--- a/numba_dppy/tests/njit_tests/dpnp_ndarray/test_models.py
+++ b/numba_dppy/tests/njit_tests/dpnp_ndarray/test_models.py
@@ -41,4 +41,4 @@ def test_dpnp_ndarray_Model():
     """
 
     assert issubclass(dpnp_ndarray_Model, models.StructModel)
-    assert not issubclass(dpnp_ndarray_Model, models.ArrayModel)
+    assert issubclass(dpnp_ndarray_Model, models.ArrayModel)

--- a/numba_dppy/tests/njit_tests/dpnp_ndarray/test_typeof.py
+++ b/numba_dppy/tests/njit_tests/dpnp_ndarray/test_typeof.py
@@ -1,0 +1,45 @@
+# Copyright 2020-2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for numba_dppy.dpnp_ndarray.typeof
+"""
+
+import pytest
+from dpctl.tensor.numpy_usm_shared import ndarray as dpctl_ndarray
+from dpnp import ndarray as dpnp_ndarray
+from numba import njit, typeof, types
+
+from numba_dppy.dpnp_ndarray import dpnp_ndarray_Type
+from numba_dppy.numpy_usm_shared import UsmSharedArrayType
+
+
+@pytest.mark.parametrize(
+    "array_type, expected_numba_type",
+    [
+        (dpctl_ndarray, UsmSharedArrayType),
+        (dpnp_ndarray, dpnp_ndarray_Type),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape, expected_ndim",
+    [
+        ([1], 1),
+        ([1, 1], 2),
+    ],
+)
+def test_typeof(array_type, shape, expected_numba_type, expected_ndim):
+    array = array_type(shape)
+    expected_type = expected_numba_type(types.float64, expected_ndim, "C")
+    assert typeof(array) == expected_type

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ def get_ext_modules():
         dpctl_runtime_library_dirs.append(os.path.dirname(dpctl.__file__))
 
     ext_dppy = Extension(
-        name="numba_dppy._usm_shared_allocator_ext",
-        sources=["numba_dppy/dpctl_iface/usm_shared_allocator_ext.c"],
+        name="numba_dppy._usm_allocators_ext",
+        sources=["numba_dppy/dpctl_iface/usm_allocators_ext.c"],
         include_dirs=[numba.core.extending.include_path(), dpctl.get_include()],
         libraries=["DPCTLSyclInterface"],
         library_dirs=[os.path.dirname(dpctl.__file__)],


### PR DESCRIPTION
- [x] Rename `usm_allocators_ext`
- [x] Add docstrings for functions in `usm_allocators_ext.c`
- [x] Remove commented code from `models.py`
- [x] Use `ArrayModel` as a model for `dpnp.ndarray`
- [x] Update tests for models and split tests for `typeof` and `boxing`